### PR TITLE
Add Faculty Calendar

### DIFF
--- a/.vscode/course-schedulizer.code-workspace
+++ b/.vscode/course-schedulizer.code-workspace
@@ -9,7 +9,6 @@
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true,
-      "source.organizeImports": true,
       "source.fixAll": true
     },
     "eslint.enable": true,

--- a/client-course-schedulizer/.eslintrc.js
+++ b/client-course-schedulizer/.eslintrc.js
@@ -25,7 +25,15 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: "module",
   },
-  plugins: ["react", "@typescript-eslint", "typescript-sort-keys", "react-hooks", "sort-keys-fix"],
+  plugins: [
+    "react",
+    "@typescript-eslint",
+    "typescript-sort-keys",
+    "react-hooks",
+    "sort-keys-fix",
+    "import",
+    "eslint-plugin-import-order-alphabetical",
+  ],
   rules: {
     // Disable some AirBnB rules.
     // Allow any linebreak type.
@@ -69,6 +77,15 @@ module.exports = {
       },
     ],
     "import/no-unresolved": "off",
+    // Sort imports by kind
+    "import/order": [
+      "error",
+      {
+        groups: ["builtin", "external", "index", "sibling", "parent", "internal"],
+      },
+    ],
+    // sort imports by letter
+    "import-order-alphabetical/order": "error",
 
     // Rules related to function definitions
     "func-style": ["error", "expression"],

--- a/client-course-schedulizer/.eslintrc.js
+++ b/client-course-schedulizer/.eslintrc.js
@@ -76,17 +76,6 @@ module.exports = {
       },
     ],
     "import/no-unresolved": "off",
-    // sort imports
-    "sort-imports": [
-      "error",
-      {
-        ignoreCase: false,
-        ignoreDeclarationSort: false,
-        ignoreMemberSort: false,
-        memberSyntaxSortOrder: ["all", "multiple", "single", "none"],
-        allowSeparatedGroups: false,
-      },
-    ],
 
     // Rules related to function definitions
     "func-style": ["error", "expression"],

--- a/client-course-schedulizer/.eslintrc.js
+++ b/client-course-schedulizer/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
 module.exports = {
   ignorePatterns: ["serviceWorker.ts", "*/_generated"],
   env: {
@@ -32,7 +33,6 @@ module.exports = {
     "react-hooks",
     "sort-keys-fix",
     "import",
-    "eslint-plugin-import-order-alphabetical",
   ],
   rules: {
     // Disable some AirBnB rules.
@@ -52,7 +52,6 @@ module.exports = {
     // Turn off rules related to Prettier. These are auto fixed.
     "max-len": "off",
     "@typescript-eslint/quotes": "off",
-    "@typescript-eslint/indent": "off",
     "arrow-parens": "off",
     "@typescript-eslint/semi": "off",
     "react/jsx-closing-bracket-location": "off",
@@ -77,15 +76,17 @@ module.exports = {
       },
     ],
     "import/no-unresolved": "off",
-    // Sort imports by kind
-    "import/order": [
+    // sort imports
+    "sort-imports": [
       "error",
       {
-        groups: ["builtin", "external", "index", "sibling", "parent", "internal"],
+        ignoreCase: false,
+        ignoreDeclarationSort: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ["all", "multiple", "single", "none"],
+        allowSeparatedGroups: false,
       },
     ],
-    // sort imports by letter
-    "import-order-alphabetical/order": "error",
 
     // Rules related to function definitions
     "func-style": ["error", "expression"],

--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -2527,9 +2527,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-globals": {
@@ -6216,17 +6216,6 @@
         }
       }
     },
-    "eslint-plugin-import-order-alphabetical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-order-alphabetical/-/eslint-plugin-import-order-alphabetical-1.0.1.tgz",
-      "integrity": "sha512-fCCIMtD7gkgziKEydRUqviVpEpY7Payg7U8erirqf8rEFpN2GshBuS9A1ClueTQ0VvXEATWTxJC6ihAIHGHDHQ==",
-      "dev": true,
-      "requires": {
-        "eslint-module-utils": "^2.2.0",
-        "lodash": "^4.17.4",
-        "resolve": "^1.6.0"
-      }
-    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
@@ -8297,12 +8286,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -13827,6 +13815,77 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
+        "eslint": {
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+          "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.3",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.2",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^12.1.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^7.0.0",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.14",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.3",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+              "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "doctrine": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+              "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+              "dev": true,
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
         "eslint-plugin-import": {
           "version": "2.20.1",
           "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
@@ -13911,6 +13970,26 @@
           "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
           "dev": true
         },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "espree": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -13918,6 +13997,25 @@
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
           }
         },
         "load-json-file": {
@@ -14016,6 +14114,18 @@
             "find-up": "^2.0.0",
             "read-pkg": "^2.0.0"
           }
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
         }
       }
     },
@@ -16625,9 +16735,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -2132,6 +2132,14 @@
         "@types/react": "*"
       }
     },
+    "@types/react-stickynode": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-stickynode/-/react-stickynode-3.0.1.tgz",
+      "integrity": "sha512-7B4UYE+/yEOp2p0mUbu/O0w1UuGiPzSB3RbkjA3UQcaF+k3VaiKdaTdah32PerfEV2WhvmvVeXnNpsm4PsDd5g==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-transition-group": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
@@ -4614,8 +4622,7 @@
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-      "dev": true
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -8391,7 +8398,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -13372,7 +13378,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -14129,6 +14134,28 @@
         }
       }
     },
+    "react-stick": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-stick/-/react-stick-4.1.1.tgz",
+      "integrity": "sha512-q4xE0/oI9djfZUs6zsfwFCp9jW0XdUOB2Ji8hSM4nACzTxOIKgNizepv+k+BICcoM7KNs9RCM+B0Wvynp96c2A==",
+      "requires": {
+        "invariant": "^2.2.4",
+        "requestidlecallback": "^0.3.0",
+        "substyle": "^9.1.0"
+      }
+    },
+    "react-stickynode": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-stickynode/-/react-stickynode-3.0.4.tgz",
+      "integrity": "sha512-0ve+RW8YG41lleor/EiBobz2w8/0KHKxmBdouYFi563hJu94C1n66FgxqRj+zS0vj8zCetvtWvO9kSU8J9RXCA==",
+      "requires": {
+        "classnames": "^2.0.0",
+        "core-js": "^3.6.5",
+        "prop-types": "^15.6.0",
+        "shallowequal": "^1.0.0",
+        "subscribe-ui-event": "^2.0.6"
+      }
+    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
@@ -14463,6 +14490,11 @@
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
+    },
+    "requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -15074,6 +15106,11 @@
           "dev": true
         }
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -15954,6 +15991,32 @@
             "uniq": "^1.0.1"
           }
         }
+      }
+    },
+    "subscribe-ui-event": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/subscribe-ui-event/-/subscribe-ui-event-2.0.7.tgz",
+      "integrity": "sha512-Acrtf9XXl6lpyHAWYeRD1xTPUQHDERfL4GHeNuYAtZMc4Z8Us2iDBP0Fn3xiRvkQ1FO+hx+qRLmPEwiZxp7FDQ==",
+      "requires": {
+        "eventemitter3": "^3.0.0",
+        "lodash": "^4.17.15",
+        "raf": "^3.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        }
+      }
+    },
+    "substyle": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/substyle/-/substyle-9.3.0.tgz",
+      "integrity": "sha512-OK6A6EpqOfRvlwOnrgwFKIi8UDJwCQ2UB5cIJGMEFvl3zUUA83XDbRUJizECj66CdeZ9pGjkmwRxyc/9wBGQMA==",
+      "requires": {
+        "@babel/runtime": "^7.3.4",
+        "invariant": "^2.2.4"
       }
     },
     "supports-color": {

--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -1332,6 +1332,22 @@
         }
       }
     },
+    "@fullcalendar/moment": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/moment/-/moment-5.3.1.tgz",
+      "integrity": "sha512-wq1KS3R3LuO/pIvmmFPQjdATsdApKjAOoNt7iXUKBvCKkcUnYn+psv+jSF/xKR/7H8QFApsgDSnMhbpPBYqzIg==",
+      "requires": {
+        "@fullcalendar/common": "~5.3.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
     "@fullcalendar/react": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-5.3.1.tgz",
@@ -10940,6 +10956,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -1285,6 +1285,86 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
+    "@fullcalendar/common": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.3.1.tgz",
+      "integrity": "sha512-2PREEpiFQSDN5MNdoD/OkpJ+d7FPtN2TwTJMsuq3fTjmj3nM+utrxBmUr9a2F6WWW1X+xGU5nHQA52vhqIiQOQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
+    "@fullcalendar/daygrid": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.3.2.tgz",
+      "integrity": "sha512-BK+YIecF3q9d/+6lAnf6WiJEEs7Wpa/mu9gXpkEf8vn4nl2bicPHUwykg5dUMCBy7ADAkDoL7VuBVi0XBRtPYw==",
+      "requires": {
+        "@fullcalendar/common": "~5.3.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
+    "@fullcalendar/interaction": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.3.1.tgz",
+      "integrity": "sha512-S1QAIazLQ7yBlUFyQbXzvXj36u39/G6H0qI2bUuQ4lY5VlUMGkiKZqb8oDHz1wE9/keuBL5CX2K/WTDGJ19Mng==",
+      "requires": {
+        "@fullcalendar/common": "~5.3.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
+    "@fullcalendar/react": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-5.3.1.tgz",
+      "integrity": "sha512-CuZSaOniy9XmISRMJcN241dGBUDIOMHU5RCCISjahIDZb7+qmQvSC572GYh3P4iYzoiMLMUtNU9flXvxASCUVw==",
+      "requires": {
+        "@fullcalendar/common": "~5.3.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
+    "@fullcalendar/timegrid": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-5.3.1.tgz",
+      "integrity": "sha512-ahyJC/kybGip5pTLC4cpsEdnhDZb3Hg0F7LTD/VVK4GxzplDiI0ZaWACC4O22zmp1+7a40NUMIV0HLO3D5SV4A==",
+      "requires": {
+        "@fullcalendar/common": "~5.3.1",
+        "@fullcalendar/daygrid": "~5.3.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -6143,14 +6223,26 @@
           }
         },
         "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "version": "1.18.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+          "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
           "dev": true,
           "requires": {
+            "is-core-module": "^2.0.0",
             "path-parse": "^1.0.6"
           }
         }
+      }
+    },
+    "eslint-plugin-import-order-alphabetical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-order-alphabetical/-/eslint-plugin-import-order-alphabetical-1.0.1.tgz",
+      "integrity": "sha512-fCCIMtD7gkgziKEydRUqviVpEpY7Payg7U8erirqf8rEFpN2GshBuS9A1ClueTQ0VvXEATWTxJC6ihAIHGHDHQ==",
+      "dev": true,
+      "requires": {
+        "eslint-module-utils": "^2.2.0",
+        "lodash": "^4.17.4",
+        "resolve": "^1.6.0"
       }
     },
     "eslint-plugin-jsx-a11y": {

--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -1983,9 +1983,9 @@
       "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA=="
     },
     "@types/babel__core": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
-      "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.11.tgz",
+      "integrity": "sha512-E5nSOzrjnvhURYnbOR2dClTqcyhPbPvtEwLHf7JJADKedPbcZsoJVfP+I2vBNfBjz4bnZIuhL/tNmRi5nJ7Jlw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -3145,21 +3145,6 @@
         "babylon": "^6.18.0"
       }
     },
-    "babel-jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
-      "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
-      "dev": true,
-      "requires": {
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "@types/babel__core": "^7.1.0",
-        "babel-plugin-istanbul": "^5.1.0",
-        "babel-preset-jest": "^24.9.0",
-        "chalk": "^2.4.2",
-        "slash": "^2.0.0"
-      }
-    },
     "babel-loader": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
@@ -3200,15 +3185,6 @@
         "find-up": "^3.0.0",
         "istanbul-lib-instrument": "^3.3.0",
         "test-exclude": "^5.2.3"
-      }
-    },
-    "babel-plugin-jest-hoist": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
-      "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
-      "dev": true,
-      "requires": {
-        "@types/babel__traverse": "^7.0.6"
       }
     },
     "babel-plugin-macros": {
@@ -3298,16 +3274,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
       "dev": true
-    },
-    "babel-preset-jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
-      "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "babel-plugin-jest-hoist": "^24.9.0"
-      }
     },
     "babel-preset-react-app": {
       "version": "9.1.2",
@@ -8920,6 +8886,42 @@
         "micromatch": "^3.1.10",
         "pretty-format": "^24.9.0",
         "realpath-native": "^1.1.0"
+      },
+      "dependencies": {
+        "babel-jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+          "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/babel__core": "^7.1.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "babel-preset-jest": "^24.9.0",
+            "chalk": "^2.4.2",
+            "slash": "^2.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+          "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+          "dev": true,
+          "requires": {
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+          "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+          "dev": true,
+          "requires": {
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "babel-plugin-jest-hoist": "^24.9.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -13764,6 +13766,40 @@
           "requires": {
             "ast-types-flow": "0.0.7",
             "commander": "^2.11.0"
+          }
+        },
+        "babel-jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+          "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/babel__core": "^7.1.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "babel-preset-jest": "^24.9.0",
+            "chalk": "^2.4.2",
+            "slash": "^2.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+          "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+          "dev": true,
+          "requires": {
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+          "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+          "dev": true,
+          "requires": {
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "babel-plugin-jest-hoist": "^24.9.0"
           }
         },
         "debug": {

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -16,11 +16,14 @@
     "@types/node": "12.12.62",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.8",
+    "@types/react-stickynode": "3.0.1",
     "material-ui-popup-state": "^1.7.0",
     "moment": "2.29.1",
     "node-sass": "4.14.1",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-stick": "4.1.1",
+    "react-stickynode": "3.0.4"
   },
   "homepage": ".",
   "scripts": {

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fullcalendar/daygrid": "5.3.2",
+    "@fullcalendar/interaction": "5.3.1",
+    "@fullcalendar/react": "5.3.1",
+    "@fullcalendar/timegrid": "5.3.1",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
@@ -49,6 +53,7 @@
     "eslint-config-airbnb": "18.2.0",
     "eslint-config-prettier": "6.12.0",
     "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-import-order-alphabetical": "1.0.1",
     "eslint-plugin-jsx-a11y": "6.3.1",
     "eslint-plugin-react": "7.21.3",
     "eslint-plugin-react-hooks": "^2.3.0",

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -55,7 +55,6 @@
     "eslint-config-airbnb": "18.2.0",
     "eslint-config-prettier": "6.12.0",
     "eslint-plugin-import": "2.22.1",
-    "eslint-plugin-import-order-alphabetical": "1.0.1",
     "eslint-plugin-jsx-a11y": "6.3.1",
     "eslint-plugin-react": "7.21.3",
     "eslint-plugin-react-hooks": "^2.3.0",

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fullcalendar/daygrid": "5.3.2",
     "@fullcalendar/interaction": "5.3.1",
+    "@fullcalendar/moment": "5.3.1",
     "@fullcalendar/react": "5.3.1",
     "@fullcalendar/timegrid": "5.3.1",
     "@material-ui/core": "^4.11.0",
@@ -17,6 +18,7 @@
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.8",
     "material-ui-popup-state": "^1.7.0",
+    "moment": "2.29.1",
     "node-sass": "4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fullcalendar/daygrid": "5.3.2",
     "@fullcalendar/interaction": "5.3.1",
     "@fullcalendar/moment": "5.3.1",
     "@fullcalendar/react": "5.3.1",

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -2,7 +2,6 @@
   "name": "client-course-schedulizer",
   "version": "0.1.0",
   "private": true,
-  "type": "module",
   "dependencies": {
     "@fullcalendar/daygrid": "5.3.2",
     "@fullcalendar/interaction": "5.3.1",

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -2,6 +2,7 @@
   "name": "client-course-schedulizer",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@fullcalendar/daygrid": "5.3.2",
     "@fullcalendar/interaction": "5.3.1",

--- a/client-course-schedulizer/src/components/App/App.test.tsx
+++ b/client-course-schedulizer/src/components/App/App.test.tsx
@@ -2,6 +2,21 @@ import { render } from "@testing-library/react";
 import React from "react";
 import { App } from "./App";
 
+// Jest doesn't work well with fullcalendar
+// see: https://github.com/fullcalendar/fullcalendar/issues/5570
+jest.mock("@fullcalendar/react", () => {
+  const aDiv = () => {
+    return <div />;
+  };
+  return aDiv;
+});
+jest.mock("@fullcalendar/timegrid", () => {
+  return jest.fn();
+});
+jest.mock("@fullcalendar/interaction", () => {
+  return jest.fn();
+});
+
 test("renders without crashing", () => {
   render(<App />);
 });

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
@@ -10,5 +10,12 @@
 }
 
 .calendar {
-  width: 600px; // This is static, and I don't like it, but I don't know how to make it better
+  width: 25vw;
+}
+
+.calendar-title {
+  // background-color: #f2f2f2;
+  background-color: lightblue;
+  z-index: 500;
+  padding: 1em;
 }

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
@@ -1,31 +1,26 @@
-.calendars-wrapper {
+@import "../../../styles/constants.scss";
+
+.schedule-wrapper {
   overflow-x: auto;
 }
 
-.calendars-adjacent {
+.adjacent {
   width: fit-content;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
 }
 
-.calendar {
+.calendar-width {
   width: 25vw;
 }
 
 .calendar-title {
-  // TODO: MAKE CSSS VARIABLES for bg color and padding/margin dependencies
-  background-color: #f2f2f2;
-  z-index: 500;
-  padding: 1em;
+  padding: $spacing;
 }
 
-.calendar-title-row {
-  margin-left: -2em;
-  padding-left: 2em;
-  background-color: #f2f2f2;
-}
-
-.top-thing {
-  top: 10vh;
+.schedule-header-row {
+  margin-left: -2 * $spacing;
+  padding-left: 2 * $spacing;
+  background-color: $bg-header;
 }

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
@@ -14,8 +14,18 @@
 }
 
 .calendar-title {
-  // background-color: #f2f2f2;
-  background-color: lightblue;
+  // TODO: MAKE CSSS VARIABLES for bg color and padding/margin dependencies
+  background-color: #f2f2f2;
   z-index: 500;
   padding: 1em;
+}
+
+.calendar-title-row {
+  margin-left: -2em;
+  padding-left: 2em;
+  background-color: #f2f2f2;
+}
+
+.top-thing {
+  top: 10vh;
 }

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.scss
@@ -1,0 +1,14 @@
+.calendars-wrapper {
+  overflow-x: auto;
+}
+
+.calendars-adjacent {
+  width: fit-content;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+}
+
+.calendar {
+  width: 600px; // This is static, and I don't like it, but I don't know how to make it better
+}

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -1,0 +1,25 @@
+import Grid from "@material-ui/core/Grid";
+import React from "react";
+import { Calendar } from "../../reuseables/Calendar";
+import { ScheduleToolbar } from "../../Toolbar/ScheduleToolbar";
+
+// TODO: remove this
+const professors = ["Norman", "Adams", "VanderLinden", "Arnold", "Bailey"];
+
+export const FacultySchedule = () => {
+  return (
+    <>
+      <ScheduleToolbar />
+      <Grid alignItems="flex-start" container direction="row" justify="flex-start">
+        {professors.map((prof, index) => {
+          return (
+            <span key={prof} className={index !== 0 ? "hide-axis" : ""} style={{ width: 600 }}>
+              <h3>{prof}</h3>
+              <Calendar key={prof} />
+            </span>
+          );
+        })}
+      </Grid>
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -16,32 +16,23 @@ const professors = [
   "Plantinga",
 ];
 
+/* Creates a list of Calendars to create the Faculty Schedule
+  <Stick> is used to stick the Schedule Header to the Schedule
+  to track horizontal scrolling.
+*/
 export const FacultySchedule = () => {
   return (
     <>
       <ScheduleToolbar />
-      <div className="calendars-wrapper">
-        <Stick
-          autoFlipVertically
-          node={
-            <StickyNode top={window.innerHeight * 0.1}>
-              <div className="calendars-adjacent calendar-title-row">
-                {professors.map((prof) => {
-                  return (
-                    <div key={prof} className="calendar calendar-title">
-                      {prof}
-                    </div>
-                  );
-                })}
-              </div>
-            </StickyNode>
-          }
-          position="top left"
-        >
-          <div className="calendars-adjacent">
+      <div className="schedule-wrapper">
+        <Stick node={<StickyHeader />} position="top left">
+          <div className="adjacent">
             {professors.map((prof, index) => {
+              const hideAxis = index !== 0 ? "hide-axis" : "";
+
               return (
-                <div key={prof} className={`calendar ${index !== 0 ? "hide-axis" : ""}`}>
+                // {/* TODO: Fix this because the first calendar is smaller */}
+                <div key={prof} className={`calendar-width ${hideAxis}`}>
                   <Calendar key={prof} />
                 </div>
               );
@@ -50,5 +41,26 @@ export const FacultySchedule = () => {
         </Stick>
       </div>
     </>
+  );
+};
+
+/*
+  StickyHeader is used to keep the Schedule header sticky to the
+  top of the view port.
+*/
+// TODO: Make into reusable component for future room schedule
+const StickyHeader = () => {
+  return (
+    <StickyNode top={window.innerHeight / 10}>
+      <div className="adjacent schedule-header-row">
+        {professors.map((prof) => {
+          return (
+            <div key={prof} className="calendar-width calendar-title">
+              {prof}
+            </div>
+          );
+        })}
+      </div>
+    </StickyNode>
   );
 };

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -1,7 +1,7 @@
-import Grid from "@material-ui/core/Grid";
 import React from "react";
 import { Calendar } from "../../reuseables/Calendar";
 import { ScheduleToolbar } from "../../Toolbar/ScheduleToolbar";
+import "./FacultySchedule.scss";
 
 // TODO: remove this
 const professors = ["Norman", "Adams", "VanderLinden", "Arnold", "Bailey"];
@@ -10,16 +10,18 @@ export const FacultySchedule = () => {
   return (
     <>
       <ScheduleToolbar />
-      <Grid alignItems="flex-start" container direction="row" justify="flex-start">
-        {professors.map((prof, index) => {
-          return (
-            <span key={prof} className={index !== 0 ? "hide-axis" : ""} style={{ width: 600 }}>
-              <h3>{prof}</h3>
-              <Calendar key={prof} />
-            </span>
-          );
-        })}
-      </Grid>
+      <div className="calendars-wrapper">
+        <div className="calendars-adjacent">
+          {professors.map((prof, index) => {
+            return (
+              <div key={prof} className={`calendar ${index !== 0 ? "hide-axis" : ""}`}>
+                <h3>{prof}</h3>
+                <Calendar key={prof} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </>
   );
 };

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -24,8 +24,8 @@ export const FacultySchedule = () => {
         <Stick
           autoFlipVertically
           node={
-            <StickyNode>
-              <div className="calendars-adjacent">
+            <StickyNode top={window.innerHeight * 0.1}>
+              <div className="calendars-adjacent calendar-title-row">
                 {professors.map((prof) => {
                   return (
                     <div key={prof} className="calendar calendar-title">

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -1,26 +1,53 @@
 import React from "react";
+import StickyNode from "react-stickynode";
+import Stick from "react-stick";
 import { Calendar } from "../../reuseables/Calendar";
 import { ScheduleToolbar } from "../../Toolbar/ScheduleToolbar";
 import "./FacultySchedule.scss";
 
 // TODO: remove this
-const professors = ["Norman", "Adams", "VanderLinden", "Arnold", "Bailey"];
+const professors = [
+  "Norman",
+  "Adams",
+  "VanderLinden",
+  "Arnold",
+  "Bailey",
+  "Schuurman",
+  "Plantinga",
+];
 
 export const FacultySchedule = () => {
   return (
     <>
       <ScheduleToolbar />
       <div className="calendars-wrapper">
-        <div className="calendars-adjacent">
-          {professors.map((prof, index) => {
-            return (
-              <div key={prof} className={`calendar ${index !== 0 ? "hide-axis" : ""}`}>
-                <h3>{prof}</h3>
-                <Calendar key={prof} />
+        <Stick
+          autoFlipVertically
+          node={
+            <StickyNode>
+              <div className="calendars-adjacent">
+                {professors.map((prof) => {
+                  return (
+                    <div key={prof} className="calendar calendar-title">
+                      {prof}
+                    </div>
+                  );
+                })}
               </div>
-            );
-          })}
-        </div>
+            </StickyNode>
+          }
+          position="top left"
+        >
+          <div className="calendars-adjacent">
+            {professors.map((prof, index) => {
+              return (
+                <div key={prof} className={`calendar ${index !== 0 ? "hide-axis" : ""}`}>
+                  <Calendar key={prof} />
+                </div>
+              );
+            })}
+          </div>
+        </Stick>
       </div>
     </>
   );

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/index.ts
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/index.ts
@@ -1,0 +1,1 @@
+export * from "./FacultySchedule";

--- a/client-course-schedulizer/src/components/Tabs/Tabs.tsx
+++ b/client-course-schedulizer/src/components/Tabs/Tabs.tsx
@@ -56,12 +56,12 @@ export const Tabs = () => {
       <TabPanel index={0} value={tabValue}>
         <ScheduleToolbar />
         <Grid alignItems="flex-start" container direction="row" justify="flex-start">
-          {professors.map((prof) => {
+          {professors.map((prof, index) => {
             return (
-              <div key={prof} style={{ width: 500 }}>
+              <span key={prof} className={index !== 0 ? "hide-axis" : ""} style={{ width: 500 }}>
                 <h3>{prof}</h3>
                 <Calendar key={prof} />
-              </div>
+              </span>
             );
           })}
         </Grid>

--- a/client-course-schedulizer/src/components/Tabs/Tabs.tsx
+++ b/client-course-schedulizer/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,6 @@
-import { Box, Paper, Tab, Tabs as MUITabs, Typography } from "@material-ui/core";
+import { Box, Grid, Paper, Tab, Tabs as MUITabs, Typography } from "@material-ui/core";
 import React, { ChangeEvent, PropsWithChildren, useState } from "react";
+import { Calendar } from "../reuseables/Calendar";
 import { ScheduleToolbar } from "../Toolbar/ScheduleToolbar";
 import "./Tabs.scss";
 
@@ -28,6 +29,9 @@ const TabPanel = (props: PropsWithChildren<TabPanelProps>) => {
   );
 };
 
+// TODO: remove this
+const professors = ["Norman", "Adams", "VanderLinden", "Arnold", "Bailey"];
+
 export const Tabs = () => {
   const [tabValue, setTabValue] = useState(0);
 
@@ -51,6 +55,16 @@ export const Tabs = () => {
       </MUITabs>
       <TabPanel index={0} value={tabValue}>
         <ScheduleToolbar />
+        <Grid alignItems="flex-start" container direction="row" justify="flex-start">
+          {professors.map((prof) => {
+            return (
+              <div key={prof} style={{ width: 500 }}>
+                <h3>{prof}</h3>
+                <Calendar key={prof} />
+              </div>
+            );
+          })}
+        </Grid>
       </TabPanel>
       <TabPanel index={1} value={tabValue}>
         <ScheduleToolbar />

--- a/client-course-schedulizer/src/components/Tabs/Tabs.tsx
+++ b/client-course-schedulizer/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
-import { Box, Grid, Paper, Tab, Tabs as MUITabs, Typography } from "@material-ui/core";
+import { Box, Tabs as MUITabs, Paper, Tab, Typography } from "@material-ui/core";
 import React, { ChangeEvent, PropsWithChildren, useState } from "react";
-import { Calendar } from "../reuseables/Calendar";
+import { FacultySchedule } from "./FacultySchedule";
 import { ScheduleToolbar } from "../Toolbar/ScheduleToolbar";
 import "./Tabs.scss";
 
@@ -29,9 +29,6 @@ const TabPanel = (props: PropsWithChildren<TabPanelProps>) => {
   );
 };
 
-// TODO: remove this
-const professors = ["Norman", "Adams", "VanderLinden", "Arnold", "Bailey"];
-
 export const Tabs = () => {
   const [tabValue, setTabValue] = useState(0);
 
@@ -54,17 +51,7 @@ export const Tabs = () => {
         <Tab label="Conflicts" />
       </MUITabs>
       <TabPanel index={0} value={tabValue}>
-        <ScheduleToolbar />
-        <Grid alignItems="flex-start" container direction="row" justify="flex-start">
-          {professors.map((prof, index) => {
-            return (
-              <span key={prof} className={index !== 0 ? "hide-axis" : ""} style={{ width: 500 }}>
-                <h3>{prof}</h3>
-                <Calendar key={prof} />
-              </span>
-            );
-          })}
-        </Grid>
+        <FacultySchedule />
       </TabPanel>
       <TabPanel index={1} value={tabValue}>
         <ScheduleToolbar />

--- a/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
+++ b/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
@@ -5,13 +5,14 @@
 }
 
 .schedule-toolbar {
-  // position: sticky;
+  position: sticky;
   top: 0;
   background-color: #f2f2f2;
   z-index: 3;
   padding: 1em;
-  // margin-left: -2em;
-  // margin-right: -2em;
+  margin-left: -2em;
+  margin-right: -2em;
+  margin-bottom: 1.5em;
   height: 10vh;
 }
 

--- a/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
+++ b/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
@@ -4,6 +4,16 @@
   justify-content: space-between;
 }
 
+.schedule-toolbar {
+  position: sticky;
+  top: 0;
+  background-color: #f2f2f2;
+  z-index: 3;
+  padding: 1em;
+  margin-left: -2em;
+  margin-right: -2em;
+}
+
 .toolbar-left {
   width: 35%;
 }

--- a/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
+++ b/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
@@ -1,3 +1,5 @@
+@import "../../../styles/constants.scss";
+
 .schedule-toolbar,
 .schedule-toolbar > div {
   display: flex;
@@ -7,13 +9,14 @@
 .schedule-toolbar {
   position: sticky;
   top: 0;
-  background-color: #f2f2f2;
+  background-color: $bg-header;
   z-index: 3;
-  padding: 1em;
-  margin-left: -2em;
-  margin-right: -2em;
-  margin-bottom: 1.5em;
-  height: 10vh;
+  padding: $spacing;
+  margin-left: -2 * $spacing;
+  margin-right: -2 * $spacing;
+  // TODO: there is slight squishing when stickied but not sure how to fix. takes time to debug
+  margin-bottom: 1.5 * $spacing;
+  min-height: 10vh;
 }
 
 .toolbar-left {

--- a/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
+++ b/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
@@ -5,13 +5,14 @@
 }
 
 .schedule-toolbar {
-  position: sticky;
+  // position: sticky;
   top: 0;
   background-color: #f2f2f2;
   z-index: 3;
   padding: 1em;
-  margin-left: -2em;
-  margin-right: -2em;
+  // margin-left: -2em;
+  // margin-right: -2em;
+  height: 10vh;
 }
 
 .toolbar-left {

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
@@ -2,3 +2,7 @@
 .hide-axis .fc-timegrid-slot-label {
   display: none;
 }
+
+.fc-day-today {
+  background-color: inherit !important;
+}

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
@@ -1,0 +1,4 @@
+// TODO: rewrite this better
+.hide-axis .fc-timegrid-slot-label {
+  display: none;
+}

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
@@ -1,4 +1,4 @@
-// TODO: rewrite this better
+// Hide axis on the calendar
 .hide-axis .fc-timegrid-slot-label {
   display: none;
 }

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
@@ -3,6 +3,7 @@
   display: none;
 }
 
+// Force today's day to have same bg as others
 .fc-day-today {
   background-color: inherit !important;
 }

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -29,7 +29,7 @@ export const Calendar = () => {
     <>
       <FullCalendar
         allDaySlot={false}
-        dayHeaderFormat={{ weekday: "long" }}
+        dayHeaderFormat={{ weekday: "short" }}
         droppable
         editable
         events={events}
@@ -40,6 +40,8 @@ export const Calendar = () => {
         nowIndicator={false}
         plugins={[interactionPlugin, timeGridPlugin]}
         selectable
+        slotMaxTime="22:00:00"
+        slotMinTime="6:00:00"
         weekends={false}
       />
     </>

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -1,26 +1,25 @@
 /* eslint-disable import-order-alphabetical/order */
 import FullCalendar, { EventInput } from "@fullcalendar/react";
+import moment from "moment";
 
 // Plugins
-import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction"; // needed for dayClick
 import timeGridPlugin from "@fullcalendar/timegrid";
 
 import React from "react";
 import "./Calendar.scss";
 
+export const initialDate = "2000-01-02";
 // TODO: remove
 const events: EventInput = [
   {
     description: "Lecture",
-    // NOTE: we need to make it be the current data
-    // Or make the calendar start at a certain date
-    end: "2020-10-27T11:30:00",
+    end: `${moment(initialDate).add(1, "days").format("YYYY-MM-DD")}T11:30:00`,
     extendedProps: {
       department: "CS",
       professor: "VanderLinden",
     },
-    start: "2020-10-27T10:30:00",
+    start: `${moment(initialDate).add(1, "days").format("YYYY-MM-DD")}T10:30:00`,
     title: "CS262",
   },
 ];
@@ -36,9 +35,11 @@ export const Calendar = () => {
         events={events}
         headerToolbar={false}
         height="auto"
+        initialDate={initialDate}
         initialView="timeGridWeek"
         nowIndicator={false}
-        plugins={[dayGridPlugin, interactionPlugin, timeGridPlugin]}
+        plugins={[interactionPlugin, timeGridPlugin]}
+        selectable
         weekends={false}
       />
     </>

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable import-order-alphabetical/order */
+import FullCalendar from "@fullcalendar/react";
+
+// Plugins
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction"; // needed for dayClick
+import timeGridPlugin from "@fullcalendar/timegrid";
+
+import React from "react";
+
+export const Calendar = () => {
+  return (
+    <>
+      <FullCalendar
+        allDaySlot={false}
+        dayHeaderFormat={{ weekday: "long" }}
+        headerToolbar={false}
+        initialView="timeGridWeek"
+        nowIndicator={false}
+        plugins={[dayGridPlugin, interactionPlugin, timeGridPlugin]}
+        weekends={false}
+      />
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -7,6 +7,7 @@ import interactionPlugin from "@fullcalendar/interaction"; // needed for dayClic
 import timeGridPlugin from "@fullcalendar/timegrid";
 
 import React from "react";
+import "./Calendar.scss";
 
 export const Calendar = () => {
   return (

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import-order-alphabetical/order */
-import FullCalendar from "@fullcalendar/react";
+import FullCalendar, { EventInput } from "@fullcalendar/react";
 
 // Plugins
 import dayGridPlugin from "@fullcalendar/daygrid";
@@ -9,13 +9,33 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 import React from "react";
 import "./Calendar.scss";
 
+// TODO: remove
+const events: EventInput = [
+  {
+    description: "Lecture",
+    // NOTE: we need to make it be the current data
+    // Or make the calendar start at a certain date
+    end: "2020-10-27T11:30:00",
+    extendedProps: {
+      department: "CS",
+      professor: "VanderLinden",
+    },
+    start: "2020-10-27T10:30:00",
+    title: "CS262",
+  },
+];
+
 export const Calendar = () => {
   return (
     <>
       <FullCalendar
         allDaySlot={false}
         dayHeaderFormat={{ weekday: "long" }}
+        droppable
+        editable
+        events={events}
         headerToolbar={false}
+        height="auto"
         initialView="timeGridWeek"
         nowIndicator={false}
         plugins={[dayGridPlugin, interactionPlugin, timeGridPlugin]}

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable import-order-alphabetical/order */
+/* eslint-disable sort-imports */
 import FullCalendar, { EventInput } from "@fullcalendar/react";
 import moment from "moment";
 

--- a/client-course-schedulizer/src/components/reuseables/Calendar/index.ts
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/index.ts
@@ -1,0 +1,1 @@
+export * from "./Calendar";

--- a/client-course-schedulizer/src/styles/constants.scss
+++ b/client-course-schedulizer/src/styles/constants.scss
@@ -1,0 +1,2 @@
+$spacing: 1em;
+$bg-header: #f2f2f2;

--- a/client-course-schedulizer/src/styles/index.scss
+++ b/client-course-schedulizer/src/styles/index.scss
@@ -9,3 +9,7 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+
+html {
+  overflow-x: hidden;
+}

--- a/client-course-schedulizer/src/types/react-stick.d.ts
+++ b/client-course-schedulizer/src/types/react-stick.d.ts
@@ -1,0 +1,6 @@
+/* eslint-disable */
+// declaring module will allow typescript to import the module
+declare module "react-stick" {
+  const Stick: any;
+  export default Stick;
+}

--- a/client-course-schedulizer/src/types/react-stick.d.ts
+++ b/client-course-schedulizer/src/types/react-stick.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
-// declaring module will allow typescript to import the module
+// TODO: add types
+// ref: https://stackoverflow.com/questions/48224858/import-require-nodejs-modules-without-types-in-typescript-in-2018
 declare module "react-stick" {
   const Stick: any;
   export default Stick;


### PR DESCRIPTION
This PR adds multiple configured and customized FullCalendars that represent the faculty schedule. FullCalendar is particular about how imports are sorted which conflicted with our rules. I struggled to find a working alternative so I got fed up and removed most of the import sorting rules. I don't think removing those rules is a huge issue, but I am open to recommendations. 

I ran into one CSS bug I couldn't solve and that was to determine the width of each individual calendar. I found that it is currently 600px wide but I want to make them dynamic rather than static. 

closes #17 

If you have issues running into ESLint, let me know and I'll tell you how to troubleshoot it. Make sure to run npm i in the client folder. 