### PR TITLE
Integrate Import with CSV to Schedule and Schedule to CSV

### DIFF
--- a/client-course-schedulizer/public/modelSchedule.csv
+++ b/client-course-schedulizer/public/modelSchedule.csv
@@ -1,7 +1,7 @@
-name,prefixes,number,section,studentHours,facultyHours,startTime,startTimeStr,duration,location,roomCapacity,year,term,half,days,globalMax,localMax,anticipatedSize,instructors,comments
-Logic and Complexity,MATH;CS;PHIL,312,A,4,4.5,blarg,12:30 PM,50,NH 232,30,2020,FA,Full,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.
-Logic and Complexity,MATH;CS;PHIL,312,B,4,4.5,blarg,1:30 PM,50,NH 232,30,2020,FA,Full,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.
-Computer Architecture Lab,ENGR,220L,C,1.5,2,cool,6:00 PM,80,SB 011A,20,2020,SP,First,TTh,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.
-Computer Architecture Lab,ENGR,220L,A,1.5,2,cool,6:00 PM,50,SB 011A,20,2020,SP,First,MWF,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.
-Statistics Theory,MATH;STAT,327,B,4,5,25:00,8:00 AM,110,Prince Conference Center GHWE,40,2020,SU,Second,MF,35,25,30,Thomas Bayes,
-Prime Number Theory,MATH,337,A,3,3,12:99,9:00 AM,50,CFAC Auditorium,200,2020,IN,Full,MWF,180,100,180,Leonhard Euler;Bernhard Riemann,
+name,prefixes,number,section,studentHours,facultyHours,startTime,duration,location,roomCapacity,year,term,semesterLength,days,globalMax,localMax,anticipatedSize,instructors,comments
+Logic and Complexity,MATH;CS;PHIL,312,A,4,4.5,12:30 PM,50,NH 232,30,2020,FA,A,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.,
+Logic and Complexity,MATH;CS;PHIL,312,B,4,4.5,1:30 PM,50,NH 232,30,2020-2021,FA,D,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.,
+Computer Architecture Lab,ENGR,220L,C,1.5,2,6:00 PM,80,SB 011A,20,2020,SP,First,TTh,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.,
+Computer Architecture Lab,ENGR,220L,A,1.5,2,6:00 PM,50,SB 011A,20,2020,SP,First,MWF,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.,
+Statistics Theory,MATH;STAT,327,B,4,5,8:00 AM,110,Prince Conference Center GHWE,40,2020,SU,Second,MF,35,25,30,Thomas Bayes,,
+Prime Number Theory,MATH,337,A,3,3,9:00 AM,50,CFAC Auditorium,200,2020,IN,Full,MWF,180,100,180,Leonhard Euler;Bernhard Riemann,,

--- a/client-course-schedulizer/src/components/App/App.tsx
+++ b/client-course-schedulizer/src/components/App/App.tsx
@@ -1,13 +1,19 @@
-import React from "react";
+import React, { useState } from "react";
 import { Header } from "../Header/Header";
 import { Tabs } from "../Tabs";
 import "./App.scss";
+import { ScheduleContext } from "../../utilities/services/context";
+import { Schedule } from "../../utilities/interfaces/dataInterfaces";
 
 export const App = () => {
+  const [schedule, setSchedule] = useState<Schedule>({ courses: [] });
+
   return (
     <div className="App">
-      <Header />
-      <Tabs />
+      <ScheduleContext.Provider value={{ schedule, setSchedule }}>
+        <Header />
+        <Tabs />
+      </ScheduleContext.Provider>
     </div>
   );
 };

--- a/client-course-schedulizer/src/components/Header/Header/Header.tsx
+++ b/client-course-schedulizer/src/components/Header/Header/Header.tsx
@@ -1,13 +1,16 @@
 import { AppBar, IconButton, Menu, MenuItem, Toolbar, Typography } from "@material-ui/core";
 import { Menu as MenuIcon } from "@material-ui/icons";
 import { bindMenu, bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
-import React from "react";
+import React, { useContext } from "react";
 import logo from "../../../assets/CalvinUniv-vert-full-color-inverse.png";
 import { ImportButton } from "../ImportButton";
+import * as writeCSV from "../../../utilities/helpers/writeCSV";
+import { ScheduleContext } from "../../../utilities/services/context";
 import "./Header.scss";
 
 export const Header = () => {
   const popupState = usePopupState({ popupId: "menu", variant: "popover" });
+  const { schedule } = useContext(ScheduleContext);
 
   return (
     <div className="header">
@@ -20,7 +23,16 @@ export const Header = () => {
             <MenuItem>
               <ImportButton />
             </MenuItem>
-            <MenuItem onClick={popupState.close}>Export CSV</MenuItem>
+            <MenuItem
+              onClick={() => {
+                // TODO: make an ExportButton component
+                popupState.close();
+                // eslint-disable-next-line no-console
+                console.log(writeCSV.scheduleToCSVString(schedule));
+              }}
+            >
+              Export CSV
+            </MenuItem>
           </Menu>
           <Typography variant="h6">Course Schedulizer</Typography>
           <img alt="Org Logo" className="org-logo" src={logo} />

--- a/client-course-schedulizer/src/components/Header/ImportButton/ImportButton.tsx
+++ b/client-course-schedulizer/src/components/Header/ImportButton/ImportButton.tsx
@@ -1,11 +1,12 @@
 import { Input, InputLabel } from "@material-ui/core";
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useContext, useEffect, useState } from "react";
 import * as readCSV from "../../../utilities/helpers/readCSV";
-import * as writeCSV from "../../../utilities/helpers/writeCSV";
+import { ScheduleContext } from "../../../utilities/services/context";
 import "./ImportButton.scss";
 
 export const ImportButton = () => {
   const [file, setFile] = useState<Blob>();
+  const { setSchedule } = useContext(ScheduleContext);
 
   useEffect(() => {
     // https://stackoverflow.com/questions/5201317/read-the-contents-of-a-file-object
@@ -13,13 +14,12 @@ export const ImportButton = () => {
     file && read.readAsBinaryString(file);
 
     read.onloadend = () => {
-      const schedule = readCSV.csvStringToSchedule(String(read.result));
+      const scheduleJSON = readCSV.csvStringToSchedule(String(read.result));
+      setSchedule(scheduleJSON);
       // eslint-disable-next-line no-console
-      console.log(schedule);
-      // eslint-disable-next-line no-console
-      console.log(writeCSV.scheduleToCSVString(schedule));
+      console.log(scheduleJSON);
     };
-  }, [file]);
+  }, [file, setSchedule]);
 
   const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     e.target.files && setFile(e.target.files[0]);

--- a/client-course-schedulizer/src/components/Header/ImportButton/ImportButton.tsx
+++ b/client-course-schedulizer/src/components/Header/ImportButton/ImportButton.tsx
@@ -1,5 +1,6 @@
 import { Input, InputLabel } from "@material-ui/core";
 import React, { ChangeEvent, useEffect, useState } from "react";
+import * as csvParser from "../../../utilities/helpers/readCSV";
 import "./ImportButton.scss";
 
 export const ImportButton = () => {
@@ -12,7 +13,7 @@ export const ImportButton = () => {
 
     read.onloadend = () => {
       // eslint-disable-next-line no-console
-      console.log(read.result);
+      console.log(csvParser.readCSV(String(read.result)));
     };
   }, [file]);
 

--- a/client-course-schedulizer/src/components/Header/ImportButton/ImportButton.tsx
+++ b/client-course-schedulizer/src/components/Header/ImportButton/ImportButton.tsx
@@ -1,6 +1,7 @@
 import { Input, InputLabel } from "@material-ui/core";
 import React, { ChangeEvent, useEffect, useState } from "react";
-import * as csvParser from "../../../utilities/helpers/readCSV";
+import * as readCSV from "../../../utilities/helpers/readCSV";
+import * as writeCSV from "../../../utilities/helpers/writeCSV";
 import "./ImportButton.scss";
 
 export const ImportButton = () => {
@@ -12,8 +13,11 @@ export const ImportButton = () => {
     file && read.readAsBinaryString(file);
 
     read.onloadend = () => {
+      const schedule = readCSV.csvStringToSchedule(String(read.result));
       // eslint-disable-next-line no-console
-      console.log(csvParser.readCSV(String(read.result)));
+      console.log(schedule);
+      // eslint-disable-next-line no-console
+      console.log(writeCSV.scheduleToCSVString(schedule));
     };
   }, [file]);
 

--- a/client-course-schedulizer/src/index.tsx
+++ b/client-course-schedulizer/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 import { App } from "./components";
 import * as serviceWorker from "./serviceWorker";
 import "./styles/index.scss";
-import * as read from "./utilities/helpers/readCSV";
 
 ReactDOM.render(
   <React.StrictMode>
@@ -16,4 +15,3 @@ ReactDOM.render(
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
 serviceWorker.unregister();
-read.readCSV();

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -203,7 +203,9 @@ const instructorCase = function instructorCase(value: string): di.Instructor[] {
   return instructors;
 };
 
-const convertToInterface = function convertToInterface(objects: papa.ParseResult<never>) {
+const convertToInterface = function convertToInterface(
+  objects: papa.ParseResult<never>,
+): di.Schedule {
   // Define variables for Schedule creation
   let sss: SpreadsheetSection;
   const schedule: di.Schedule = {
@@ -296,7 +298,9 @@ const convertToInterface = function convertToInterface(objects: papa.ParseResult
         }
         case "startTimeStr":
         case "startTime": {
-          firstMeeting.startTime = startTimeCase(sss, value);
+          if (value) {
+            firstMeeting.startTime = startTimeCase(sss, value);
+          }
           break;
         }
         case "duration": {
@@ -354,6 +358,11 @@ const convertToInterface = function convertToInterface(objects: papa.ParseResult
       }
     });
 
+    // Check if the meeting is empty, and should be removed
+    if (firstMeeting.days === [] || firstMeeting.duration === 0) {
+      sss.meetings = [];
+    }
+
     // Create a section for this row of the CSV, and add it to the schedule
     const section: di.Section = {
       // TODO: Allow for multiple meetings
@@ -364,14 +373,6 @@ const convertToInterface = function convertToInterface(objects: papa.ParseResult
   return schedule;
 };
 
-export const readCSV = function readCSV() {
-  // Referenced https://jscharting.com/tutorials/js-chart-data/client-side/fetch-csv-and-json/
-  fetch("modelSchedule.csv")
-    .then((response) => {
-      return response.text();
-    })
-    .then((text) => {
-      // eslint-disable-next-line no-console
-      console.log(convertToInterface(papa.parse(text, { header: true, skipEmptyLines: true })));
-    });
+export const readCSV = function readCSV(csvText: string): di.Schedule {
+  return convertToInterface(papa.parse(csvText, { header: true, skipEmptyLines: true }));
 };

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -251,10 +251,14 @@ export const csvStringToSchedule = (csvString: string): di.Schedule => {
   // This is because Pruim's data has a timestamp in "startTime" (not our timezone)
   // If both "half" and "semesterLength" are present, ignore "semesterLength"
   // If both "instructor" and "instructors" are present, ignore "instructor"
+  let duplicateFields: string[];
   duplicates.forEach((duplicate) => {
-    if (usableFields.includes(duplicate[0]) && usableFields.includes(duplicate[1])) {
-      usableFields.splice(usableFields.indexOf(duplicate[0]), 1);
-    }
+    duplicateFields = duplicate.filter((d) => {
+      return usableFields.includes(d);
+    });
+    duplicateFields.slice(0, duplicateFields.length - 1).forEach((dd) => {
+      usableFields.splice(usableFields.indexOf(dd), 1);
+    });
   });
 
   // Parse each row of the CSV as an object

--- a/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
@@ -1,19 +1,30 @@
 import * as di from "../interfaces/dataInterfaces";
 
-const convertFromInterface = function convertFromInterface(schedule: di.Schedule): string {
+export const scheduleToCSVString = (schedule: di.Schedule): string => {
   let csvStr =
-    "name,prefixes,number,section,studentHours,facultyHours,startTime,duration,location,roomCapacity,year,term,half,days,globalMax,localMax,anticipatedSize,instructors,comments";
-  schedule.sections.forEach((section) => {
-    const meeting = section.meetings ? section.meetings[0] : null;
-    csvStr += `\n${section.course.name},${section.course.prefixes},${section.course.number},${
-      section.letter
-    },${section.studentHours ?? section.course.studentHours},${
-      section.facultyHours ?? section.course.facultyHours
-    },${meeting ? meeting.startTime : ""},${meeting ? meeting.duration : ""},${
-      meeting ? meeting.location.building + meeting.location.roomNumber : ""
-    },${meeting ? meeting.location.roomCapacity : ""},${section.year},${section.term},${
-      section.half
-    },${meeting ? meeting.days : ""}`;
+    "name,prefixes,number,section,studentHours,facultyHours,startTime,duration,location,roomCapacity,year,term,semesterLength,days,globalMax,localMax,anticipatedSize,instructors,comments";
+  schedule.courses.forEach((course) => {
+    course.sections.forEach((section) => {
+      // TODO: Instead of getting the first meeting, iterate through all meetings
+      // TODO: Be wary of commas in strings?
+      let instructorsStr = "";
+      section.instructors.forEach((instructor) => {
+        instructorsStr += `${instructor.firstName} ${instructor.lastName};`;
+      });
+      instructorsStr = instructorsStr.slice(0, -1);
+      const meeting = section.meetings ? section.meetings[0] : null;
+      csvStr += `\n${course.name},${course.prefixes.join(";")},${course.number},${section.letter},${
+        section.studentHours ?? course.studentHours
+      },${section.facultyHours ?? course.facultyHours},${meeting ? meeting.startTime : ""},${
+        meeting ? meeting.duration : ""
+      },${meeting ? `${meeting.location.building} ${meeting.location.roomNumber}` : ""},${
+        meeting ? meeting.location.roomCapacity : ""
+      },${section.year},${section.term},${section.semesterLength},${
+        meeting ? meeting.days.join("") : ""
+      },${section.globalMax},${section.localMax},${section.anticipatedSize},${instructorsStr},${
+        section.comments
+      },`;
+    });
   });
   return csvStr;
 };

--- a/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
@@ -1,0 +1,19 @@
+import * as di from "../interfaces/dataInterfaces";
+
+const convertFromInterface = function convertFromInterface(schedule: di.Schedule): string {
+  let csvStr =
+    "name,prefixes,number,section,studentHours,facultyHours,startTime,duration,location,roomCapacity,year,term,half,days,globalMax,localMax,anticipatedSize,instructors,comments";
+  schedule.sections.forEach((section) => {
+    const meeting = section.meetings ? section.meetings[0] : null;
+    csvStr += `\n${section.course.name},${section.course.prefixes},${section.course.number},${
+      section.letter
+    },${section.studentHours ?? section.course.studentHours},${
+      section.facultyHours ?? section.course.facultyHours
+    },${meeting ? meeting.startTime : ""},${meeting ? meeting.duration : ""},${
+      meeting ? meeting.location.building + meeting.location.roomNumber : ""
+    },${meeting ? meeting.location.roomCapacity : ""},${section.year},${section.term},${
+      section.half
+    },${meeting ? meeting.days : ""}`;
+  });
+  return csvStr;
+};

--- a/client-course-schedulizer/src/utilities/services/context.ts
+++ b/client-course-schedulizer/src/utilities/services/context.ts
@@ -1,0 +1,18 @@
+import { createContext } from "react";
+import { Schedule } from "../interfaces/dataInterfaces";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const voidFn = () => {};
+
+interface ScheduleContext {
+  schedule: Schedule;
+  setSchedule: React.Dispatch<React.SetStateAction<Schedule>> | (() => void);
+}
+
+/* Used for containing the Schedule JSON object
+  manipulated by the web-app.
+*/
+export const ScheduleContext = createContext<ScheduleContext>({
+  schedule: { courses: [] },
+  setSchedule: voidFn,
+});


### PR DESCRIPTION
This branch does a few things:
1. Feeds the CSV gathered from the import button into the code in `readCSV.ts`.
2. Updates and simplifies some code in `readCSV.ts` (particularly with regard to the recent changes to the interfaces).
3. Adds an initial version of schedule to CSV conversion code in `writeCSV.ts`.
4. Updates `modelSchedule.csv` to reflect the new interfaces as well as removing some accidentally committed stuff.

For #20 this leaves a couple tasks:
1. Have the export button actually export the generated CSV text as a file. (Where will the schedule object will be stored, once gathered from the imported CSV?)
2. Improve on the schedule to CSV conversion code such that commas wont mess up the CSV. (Necessary or not? If necessary, still maybe not worth it right now due to rarity?)

To Test: click the import button, and import `modelSchedule.csv`. The console should log the schedule object followed by the CSV text which results from converting that schedule object (using the code in `writeCSV.ts`). Try using something like [Diff Checker](https://www.diffchecker.com/) to compare the logged CSV text with the contents of `modelSchedule.csv`, and notice that they are identical.

Closes #21 