### PR TITLE
Add teaching loads table

### DIFF
--- a/client-course-schedulizer/.eslintrc.js
+++ b/client-course-schedulizer/.eslintrc.js
@@ -116,6 +116,7 @@ module.exports = {
     "no-nested-ternary": "off",
 
     "no-unused-expressions": ["error", { allowShortCircuit: true }],
+    "no-param-reassign": "off",
 
     // Enforce the same syntax for all arrow functions
     "arrow-body-style": ["error", "always"],

--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -2154,6 +2154,14 @@
         "@types/react": "*"
       }
     },
+    "@types/react-table": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.0.25.tgz",
+      "integrity": "sha512-MLWxIiFKIW2CjcB8yQ5LfLNyVfwXfIYm2yrQfTkroK5tJ3Ai+Xzq73EQcdKWQvi/nLk431v2WV0cf30VQV+5Ow==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-transition-group": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
@@ -14199,6 +14207,11 @@
         "shallowequal": "^1.0.0",
         "subscribe-ui-event": "^2.0.6"
       }
+    },
+    "react-table": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.6.1.tgz",
+      "integrity": "sha512-XQyvombPoFbNiDHWAXdxbN78kFpsT1/aJuRSupFfBhO3FJtEVIIq2xbV1NvLzrd1YwfCYRm07ln5OHlfz0SXBg=="
     },
     "react-transition-group": {
       "version": "4.4.1",

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@hookform/resolvers": "^1.0.0",
     "@fullcalendar/interaction": "5.3.1",
     "@fullcalendar/moment": "5.3.1",
     "@fullcalendar/react": "5.3.1",
     "@fullcalendar/timegrid": "5.3.1",
+    "@hookform/resolvers": "^1.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
@@ -17,8 +17,9 @@
     "@types/node": "12.12.62",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.8",
-    "@types/yup": "^0.29.9",
     "@types/react-stickynode": "3.0.1",
+    "@types/react-table": "^7.0.25",
+    "@types/yup": "^0.29.9",
     "material-ui-popup-state": "^1.7.0",
     "moment": "2.29.1",
     "node-sass": "4.14.1",
@@ -26,9 +27,10 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-hook-form": "^6.9.6",
-    "yup": "^0.29.3",
     "react-stick": "4.1.1",
-    "react-stickynode": "3.0.4"
+    "react-stickynode": "3.0.4",
+    "react-table": "^7.6.1",
+    "yup": "^0.29.3"
   },
   "homepage": ".",
   "scripts": {

--- a/client-course-schedulizer/public/modelSchedule.csv
+++ b/client-course-schedulizer/public/modelSchedule.csv
@@ -1,7 +1,7 @@
 name,prefixes,number,section,studentHours,facultyHours,startTime,duration,location,roomCapacity,year,term,semesterLength,days,globalMax,localMax,anticipatedSize,instructors,comments
-Logic and Complexity,MATH;CS;PHIL,312,A,4,4.5,12:30 PM,50,NH 232,30,2020,FA,A,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.,
-Logic and Complexity,MATH;CS;PHIL,312,B,4,4.5,1:30 PM,50,NH 232,30,2020-2021,FA,D,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.,
-Computer Architecture Lab,ENGR,220L,C,1.5,2,6:00 PM,80,SB 011A,20,2020,SP,First,TTh,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.,
-Computer Architecture Lab,ENGR,220L,A,1.5,2,6:00 PM,50,SB 011A,20,2020,SP,First,MWF,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.,
-Statistics Theory,MATH;STAT,327,B,4,5,8:00 AM,110,Prince Conference Center GHWE,40,2020,SU,Second,MF,35,25,30,Thomas Bayes,,
-Prime Number Theory,MATH,337,A,3,3,9:00 AM,50,CFAC Auditorium,200,2020,IN,Full,MWF,180,100,180,Leonhard Euler;Bernhard Riemann,,
+Logic and Complexity,MATH;CS;PHIL,312,A,4,4.5,12:30 PM,50,NH 232,30,2020,FA,A,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.
+Logic and Complexity,MATH;CS;PHIL,312,B,4,4.5,1:30 PM,50,NH 232,30,2020-2021,FA,D,MWThF,30,20,27,Paul Erdos,This class counts for both CS and Math credit.
+Computer Architecture Lab,ENGR,220L,C,1.5,2,6:00 PM,80,SB 011A,20,2020,SP,First,TTh,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.
+Computer Architecture Lab,ENGR,220L,A,1.5,2,6:00 PM,50,SB 011A,20,2020,SP,First,MWF,20,10,15,Srinivasa Ramanujan,This class is a lab for ENGR 220.
+Statistics Theory,MATH;STAT,327,B,4,5,8:00 AM,110,Prince Conference Center GHWE,40,2020,SU,Second,MF,35,25,30,Thomas Bayes,
+Prime Number Theory,MATH,337,A,3,3,9:00 AM,50,CFAC Auditorium,200,2020,FA,Full,MWF,180,100,180,Leonhard Euler;Bernhard Riemann,

--- a/client-course-schedulizer/src/components/Tabs/FacultyLoads/FacultyLoads.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultyLoads/FacultyLoads.tsx
@@ -1,0 +1,173 @@
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from "@material-ui/core";
+import React, { useContext, useMemo } from "react";
+import { Column, useTable } from "react-table";
+import { Schedule, Term } from "../../../utilities/interfaces/dataInterfaces";
+import { ScheduleContext } from "../../../utilities/services/context";
+
+interface TableData {
+  faculty: string;
+  fallCourseSections?: string;
+  fallHours?: number;
+  loadNotes?: string;
+  otherDuties?: string;
+  otherHours?: number;
+  springCourseSections?: string;
+  springHours?: number;
+  summerCourseSections?: string;
+  summerHours?: number;
+  totalHours?: number;
+}
+
+const createTable = (schedule: Schedule): TableData[] => {
+  const newTableData: TableData[] = [];
+  schedule.courses.forEach((course) => {
+    course.sections.forEach((section) => {
+      section.instructors.forEach((instructor) => {
+        const instructorFullName = `${instructor.firstName} ${instructor.lastName}`;
+        const sectionName = `${course.prefixes[0]}-${course.number}-${section.letter}`;
+        const newDataRow: TableData = {
+          faculty: instructorFullName,
+        };
+        const [oldDataRow] = newTableData.filter((data) => {
+          return data.faculty === instructorFullName;
+        });
+        switch (section.term) {
+          case Term.Fall:
+            newDataRow.fallCourseSections = oldDataRow?.fallCourseSections
+              ? `${oldDataRow.fallCourseSections}, ${sectionName}`
+              : sectionName;
+            newDataRow.fallHours = oldDataRow?.fallHours
+              ? oldDataRow.fallHours + (section.facultyHours || course.facultyHours)
+              : section.facultyHours || course.facultyHours;
+            break;
+          case Term.Spring:
+            newDataRow.springCourseSections = oldDataRow?.springCourseSections
+              ? `${oldDataRow.springCourseSections}, ${sectionName}`
+              : sectionName;
+            newDataRow.springHours = oldDataRow?.springHours
+              ? oldDataRow.springHours + (section.facultyHours || course.facultyHours)
+              : section.facultyHours || course.facultyHours;
+            break;
+          case Term.Summer:
+            newDataRow.summerCourseSections = oldDataRow?.summerCourseSections
+              ? `${oldDataRow?.summerCourseSections}, ${sectionName}`
+              : sectionName;
+            newDataRow.summerHours = oldDataRow?.summerHours
+              ? oldDataRow?.summerHours + (section.facultyHours || course.facultyHours)
+              : section.facultyHours || course.facultyHours;
+            break;
+          default:
+            break;
+        }
+        if (oldDataRow) {
+          newTableData[newTableData.indexOf(oldDataRow)] = newDataRow;
+        } else {
+          newTableData.push(newDataRow);
+        }
+      });
+    });
+  });
+  return newTableData.map((row) => {
+    return {
+      ...row,
+      totalHours: (row.fallHours || 0) + (row.springHours || 0) + (row.summerHours || 0),
+    };
+  });
+};
+
+export const FacultyLoads = () => {
+  const { schedule } = useContext(ScheduleContext);
+
+  const data = useMemo<TableData[]>(() => {
+    return createTable(schedule);
+  }, [schedule]);
+
+  // TODO: Add Other Duties/Hours and Load Notes
+  const columns = useMemo<Column<TableData>[]>(() => {
+    return [
+      { Header: "Faculty", accessor: "faculty" },
+      { Header: "Fall Course Sections", accessor: "fallCourseSections" },
+      { Header: "Fall Hours", accessor: "fallHours" },
+      { Header: "Spring Course Sections", accessor: "springCourseSections" },
+      { Header: "Spring Hours", accessor: "springHours" },
+      { Header: "Summer Course Sections", accessor: "summerCourseSections" },
+      { Header: "Summer Hours", accessor: "summerHours" },
+      { Header: "Total Hours", accessor: "totalHours" },
+    ];
+  }, []);
+  const tableInstance = useTable({ columns, data });
+
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = tableInstance;
+
+  // https://react-table.tanstack.com/docs/quick-start
+  return (
+    // apply the table props
+    <TableContainer component={Paper}>
+      <Table {...getTableProps()}>
+        <TableHead>
+          {
+            // Loop over the header rows
+            headerGroups.map((headerGroup) => {
+              return (
+                // Apply the header row props
+                <TableRow {...headerGroup.getHeaderGroupProps()} key={headerGroup.id}>
+                  {
+                    // Loop over the headers in each row
+                    headerGroup.headers.map((column) => {
+                      return (
+                        // Apply the header cell props
+                        <TableCell {...column.getHeaderProps()} key={column.id}>
+                          {
+                            // Render the header
+                            column.render("Header")
+                          }
+                        </TableCell>
+                      );
+                    })
+                  }
+                </TableRow>
+              );
+            })
+          }
+        </TableHead>
+        {/* Apply the table body props */}
+        <TableBody {...getTableBodyProps()}>
+          {
+            // Loop over the table rows
+            rows.map((row) => {
+              // Prepare the row for display
+              prepareRow(row);
+              return (
+                // Apply the row props
+                <TableRow {...row.getRowProps()} key={row.id}>
+                  {
+                    // Loop over the rows cells
+                    row.cells.map((cell) => {
+                      // Apply the cell props
+                      return (
+                        <TableCell {...cell.getCellProps()} key={cell.value}>
+                          {
+                            // Render the cell contents
+                            cell.render("Cell")
+                          }
+                        </TableCell>
+                      );
+                    })
+                  }
+                </TableRow>
+              );
+            })
+          }
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/client-course-schedulizer/src/components/Tabs/FacultyLoads/FacultyLoads.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultyLoads/FacultyLoads.tsx
@@ -44,11 +44,8 @@ const updateRow = ({
   sectionName,
   termName,
 }: UpdateRowParams) => {
-  const termCourseSectionProp = `${termName}CourseSections` as
-    | "fallCourseSections"
-    | "springCourseSections"
-    | "summerCourseSections";
-  const termHoursProp = `${termName}Hours` as "fallHours" | "springHours" | "summerHours";
+  const termCourseSectionProp = `${termName}CourseSections` as sectionKeys;
+  const termHoursProp = `${termName}Hours` as hourKeys;
   newRow[termCourseSectionProp] = prevRow?.[termCourseSectionProp]
     ? `${prevRow[termCourseSectionProp]}, ${sectionName}`
     : sectionName;

--- a/client-course-schedulizer/src/components/Tabs/FacultyLoads/FacultyLoads.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultyLoads/FacultyLoads.tsx
@@ -12,19 +12,19 @@ import { Column, useTable } from "react-table";
 import { Schedule, Term } from "../../../utilities/interfaces/dataInterfaces";
 import { ScheduleContext } from "../../../utilities/services/context";
 
-interface TableData {
-  faculty: string;
-  fallCourseSections?: string;
-  fallHours?: number;
-  loadNotes?: string;
-  otherDuties?: string;
-  otherHours?: number;
-  springCourseSections?: string;
-  springHours?: number;
-  summerCourseSections?: string;
-  summerHours?: number;
-  totalHours?: number;
-}
+type hourKeys = "fallHours" | "springHours" | "summerHours" | "totalHours" | "otherHours";
+type sectionKeys = "fallCourseSections" | "springCourseSections" | "summerCourseSections";
+
+type TableData = {
+  [key in hourKeys]?: number;
+} &
+  {
+    [key in sectionKeys]?: string;
+  } & {
+    faculty: string;
+    loadNotes?: string;
+    otherDuties?: string;
+  };
 
 const createTable = (schedule: Schedule): TableData[] => {
   const newTableData: TableData[] = [];
@@ -118,7 +118,10 @@ export const FacultyLoads = () => {
             headerGroups.map((headerGroup) => {
               return (
                 // Apply the header row props
-                <TableRow {...headerGroup.getHeaderGroupProps()} key={headerGroup.id}>
+                <TableRow
+                  {...headerGroup.getHeaderGroupProps()}
+                  key={JSON.stringify(headerGroup.id)}
+                >
                   {
                     // Loop over the headers in each row
                     headerGroup.headers.map((column) => {

--- a/client-course-schedulizer/src/components/Tabs/FacultyLoads/index.ts
+++ b/client-course-schedulizer/src/components/Tabs/FacultyLoads/index.ts
@@ -1,0 +1,1 @@
+export * from "./FacultyLoads";

--- a/client-course-schedulizer/src/components/Tabs/Tabs.tsx
+++ b/client-course-schedulizer/src/components/Tabs/Tabs.tsx
@@ -3,6 +3,7 @@ import React, { ChangeEvent, PropsWithChildren, useState } from "react";
 import { FacultySchedule } from "./FacultySchedule";
 import { ScheduleToolbar } from "../Toolbar/ScheduleToolbar";
 import "./Tabs.scss";
+import { FacultyLoads } from "./FacultyLoads";
 
 interface TabPanelProps {
   index: number;
@@ -57,7 +58,7 @@ export const Tabs = () => {
         <ScheduleToolbar />
       </TabPanel>
       <TabPanel index={2} value={tabValue}>
-        Item Three
+        <FacultyLoads />
       </TabPanel>
       <TabPanel index={3} value={tabValue}>
         Item Four

--- a/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
+++ b/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
@@ -11,7 +11,7 @@ const timeReg = RegExp("(?<![1-9])(1[0-9]|2[0-3]|[0-9]):([0-5][0-9])");
 const amReg = RegExp("[Aa][Mm]");
 const pmReg = RegExp("[Pp][Mm]");
 const fallReg = RegExp("[Ff]");
-const summerReg = RegExp("[Ss][Uu]");
+const summerReg = RegExp("[Ss][Uu]|[Mm][Aa]");
 const springReg = RegExp("[Ss](?![Uu])");
 // "W" represents interim in Pruim's system it seems
 const interimReg = RegExp("[Ii]|[Ww]");
@@ -64,6 +64,8 @@ export const startTimeCase = (value: string, { firstMeeting }: CaseCallbackParam
 
     // Piece the time together
     firstMeeting.startTime = `${hourPart}:${minPart} ${ampm}`;
+  } else if (value === "") {
+    firstMeeting.startTime = "ASYNC";
   } else {
     // eslint-disable-next-line no-console
     console.log(`Time of "${value}" is unreadable, defaulting to 8:00 AM`);


### PR DESCRIPTION
This adds a table to the Teaching Loads tab. It's in a similar format to Prof. Vander Linden's spreadsheet. `Other Duties`, `Other Hours`, and `Load Notes` still need to be added to the table, but I think they should be in a different PR since we need to think more about how those will be added and saved.