### PR TITLE
Add events to calendar

### DIFF
--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -13,12 +13,7 @@ export const FacultySchedule = () => {
 
   return (
     <>
-      <Schedule
-        calendarHeaders={professors}
-        groupedEvents={getEvents(schedule, "faculty")}
-        slotMaxTime="22:00"
-        slotMinTime="6:00"
-      />
+      <Schedule calendarHeaders={professors} groupedEvents={getEvents(schedule, "faculty")} />
     </>
   );
 };

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -2,17 +2,23 @@ import React, { useContext } from "react";
 import "./FacultySchedule.scss";
 import { Schedule } from "../../reuseables/Schedule";
 import { AppContext } from "../../../utilities/services/appContext";
+import { getFacultyEvents } from "../../../utilities/services/facultySchedule";
 
 /* Creates a list of Calendars to create the Faculty Schedule
  */
 export const FacultySchedule = () => {
   const {
-    appState: { professors },
+    appState: { professors, schedule },
   } = useContext(AppContext);
 
   return (
     <>
-      <Schedule calendarHeaders={professors} slotMaxTime="22:00" slotMinTime="6:00" />
+      <Schedule
+        calendarHeaders={professors}
+        events={getFacultyEvents(schedule)}
+        slotMaxTime="22:00"
+        slotMinTime="6:00"
+      />
     </>
   );
 };

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import "./FacultySchedule.scss";
 import { Schedule } from "../../reuseables/Schedule";
 import { AppContext } from "../../../utilities/services/appContext";
-import { getFacultyEvents } from "../../../utilities/services/facultySchedule";
+import { getEvents } from "../../../utilities/services/schedule";
 
 /* Creates a list of Calendars to create the Faculty Schedule
  */
@@ -15,7 +15,7 @@ export const FacultySchedule = () => {
     <>
       <Schedule
         calendarHeaders={professors}
-        events={getFacultyEvents(schedule)}
+        groupedEvents={getEvents(schedule, "faculty")}
         slotMaxTime="22:00"
         slotMinTime="6:00"
       />

--- a/client-course-schedulizer/src/components/Toolbar/SemesterSelector/SemesterSelector.tsx
+++ b/client-course-schedulizer/src/components/Toolbar/SemesterSelector/SemesterSelector.tsx
@@ -1,16 +1,43 @@
 import { IconButton, Typography } from "@material-ui/core";
 import { ChevronLeft, ChevronRight } from "@material-ui/icons";
-import React from "react";
+import React, { useContext } from "react";
+import { Term } from "../../../utilities/interfaces/dataInterfaces";
+import { AppContext } from "../../../utilities/services/appContext";
 import "./SemesterSelector.scss";
 
 export const SemesterSelector = () => {
+  const terms: Term[] = Object.keys(Term).map((term) => {
+    return Term[term as keyof typeof Term];
+  });
+  const {
+    appState: { selectedTerm },
+    appDispatch,
+  } = useContext(AppContext);
   return (
     <div className="semester-selector">
-      <IconButton>
+      <IconButton
+        disabled={selectedTerm === terms[0]}
+        onClick={() => {
+          const newTerm = terms[terms.indexOf(selectedTerm) - 1];
+          appDispatch({
+            payload: { term: newTerm },
+            type: "setSelectedTerm",
+          });
+        }}
+      >
         <ChevronLeft />
       </IconButton>
-      <Typography variant="h6">Fall 2021</Typography>
-      <IconButton>
+      <Typography variant="h6">{selectedTerm}</Typography>
+      <IconButton
+        disabled={selectedTerm === terms[terms.length - 1]}
+        onClick={() => {
+          const newTerm = terms[terms.indexOf(selectedTerm) + 1];
+          appDispatch({
+            payload: { term: newTerm },
+            type: "setSelectedTerm",
+          });
+        }}
+      >
         <ChevronRight />
       </IconButton>
     </div>

--- a/client-course-schedulizer/src/components/Toolbar/SemesterSelector/SemesterSelector.tsx
+++ b/client-course-schedulizer/src/components/Toolbar/SemesterSelector/SemesterSelector.tsx
@@ -1,42 +1,40 @@
 import { IconButton, Typography } from "@material-ui/core";
 import { ChevronLeft, ChevronRight } from "@material-ui/icons";
 import React, { useContext } from "react";
+import { enumArray } from "../../../utilities/helpers/utils";
 import { Term } from "../../../utilities/interfaces/dataInterfaces";
 import { AppContext } from "../../../utilities/services/appContext";
 import "./SemesterSelector.scss";
 
 export const SemesterSelector = () => {
-  const terms: Term[] = Object.keys(Term).map((term) => {
-    return Term[term as keyof typeof Term];
-  });
+  const terms: Term[] = enumArray(Term);
   const {
     appState: { selectedTerm },
     appDispatch,
   } = useContext(AppContext);
+
+  const handleOnClick = (index: number) => {
+    return () => {
+      const newTerm = terms[index];
+      appDispatch({
+        payload: { term: newTerm },
+        type: "setSelectedTerm",
+      });
+    };
+  };
+
   return (
     <div className="semester-selector">
       <IconButton
         disabled={selectedTerm === terms[0]}
-        onClick={() => {
-          const newTerm = terms[terms.indexOf(selectedTerm) - 1];
-          appDispatch({
-            payload: { term: newTerm },
-            type: "setSelectedTerm",
-          });
-        }}
+        onClick={handleOnClick(terms.indexOf(selectedTerm) - 1)}
       >
         <ChevronLeft />
       </IconButton>
       <Typography variant="h6">{selectedTerm}</Typography>
       <IconButton
         disabled={selectedTerm === terms[terms.length - 1]}
-        onClick={() => {
-          const newTerm = terms[terms.indexOf(selectedTerm) + 1];
-          appDispatch({
-            payload: { term: newTerm },
-            type: "setSelectedTerm",
-          });
-        }}
+        onClick={handleOnClick(terms.indexOf(selectedTerm) + 1)}
       >
         <ChevronRight />
       </IconButton>

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
@@ -7,3 +7,7 @@
 .fc-day-today {
   background-color: inherit !important;
 }
+
+.fc-event-title {
+  font-size: 0.7vw;
+}

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -22,8 +22,8 @@ export const Calendar = (props: CalendarOptions) => {
 Calendar.defaultProps = {
   allDaySlot: false,
   dayHeaderFormat: { weekday: "short" },
-  droppable: true,
-  editable: false, // TODO: Change to true if we can leek section meeting times
+  droppable: false,
+  editable: false, // TODO: Change to true if we can lock section meeting times
   headerToolbar: false,
   height: "auto",
   initialDate,

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable sort-imports */
-import FullCalendar, { EventInput } from "@fullcalendar/react";
-import moment from "moment";
+import FullCalendar from "@fullcalendar/react";
 import { CalendarOptions } from "@fullcalendar/common";
 
 // Plugins
@@ -11,19 +10,6 @@ import React from "react";
 import "./Calendar.scss";
 
 export const initialDate = "2000-01-02";
-// TODO: remove
-const events: EventInput = [
-  {
-    description: "Lecture",
-    end: `${moment(initialDate).add(1, "days").format("YYYY-MM-DD")}T11:30:00`,
-    extendedProps: {
-      department: "CS",
-      professor: "VanderLinden",
-    },
-    start: `${moment(initialDate).add(1, "days").format("YYYY-MM-DD")}T10:30:00`,
-    title: "CS262",
-  },
-];
 
 export const Calendar = (props: CalendarOptions) => {
   return (
@@ -37,8 +23,7 @@ Calendar.defaultProps = {
   allDaySlot: false,
   dayHeaderFormat: { weekday: "short" },
   droppable: true,
-  editable: true,
-  events,
+  editable: false, // TODO: Change to true if we can leek section meeting times
   headerToolbar: false,
   height: "auto",
   initialDate,

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -1,10 +1,14 @@
 import { CalendarOptions } from "@fullcalendar/react";
-import { filter, forOwn } from "lodash";
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Stick from "react-stick";
 import StickyNode from "react-stickynode";
 import { AppContext } from "../../../utilities/services/appContext";
-import { GroupedEvents, getHoursArr } from "../../../utilities/services/schedule";
+import {
+  GroupedEvents,
+  getHoursArr,
+  filterEventsByTerm,
+  filterHeadersWithNoEvents,
+} from "../../../utilities/services/schedule";
 
 import { ScheduleToolbar } from "../../Toolbar/ScheduleToolbar";
 import { Calendar } from "../Calendar";
@@ -40,22 +44,12 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
 
   // Filter out events from other terms
   useEffect(() => {
-    const tempGroupedEvents: GroupedEvents = {};
-    forOwn(groupedEvents, (_, key) => {
-      tempGroupedEvents[key] = filter(groupedEvents[key], (e) => {
-        return e.extendedProps?.section.term === selectedTerm;
-      });
-    });
-    setFilteredEvents(tempGroupedEvents);
+    setFilteredEvents(filterEventsByTerm(groupedEvents, selectedTerm));
   }, [groupedEvents, selectedTerm]);
 
   // Filter out headers with no events
   useEffect(() => {
-    const tempHeaders = filter(calendarHeaders, (header) => {
-      const groupEvents = filteredEvents[header];
-      return groupEvents?.length > 0;
-    });
-    setFilteredHeaders(tempHeaders);
+    setFilteredHeaders(filterHeadersWithNoEvents(filteredEvents, calendarHeaders));
   }, [filteredEvents, calendarHeaders]);
 
   return (

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -38,7 +38,7 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
               {/* TODO: Remove calendars with no events */}
               {calendarHeaders.map((header) => {
                 const groupEvents = groupedEvents[header];
-                const groupEventsInTerm = groupEvents.filter((e) => {
+                const groupEventsInTerm = groupEvents?.filter((e) => {
                   return e.extendedProps?.section.term === selectedTerm;
                 });
                 return (

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -1,27 +1,28 @@
-import { CalendarOptions, EventInput } from "@fullcalendar/react";
+import { CalendarOptions } from "@fullcalendar/react";
 import React, { useContext } from "react";
 import Stick from "react-stick";
 import StickyNode from "react-stickynode";
 import { AppContext } from "../../../utilities/services/appContext";
-import { getHoursArr } from "../../../utilities/services/schedule";
+import { GroupedEvents, getHoursArr } from "../../../utilities/services/schedule";
+
 import { ScheduleToolbar } from "../../Toolbar/ScheduleToolbar";
 import { Calendar } from "../Calendar";
 import "./Schedule.scss";
 
 interface Schedule extends CalendarOptions {
   calendarHeaders: string[];
+  groupedEvents: GroupedEvents;
 }
 
 /* Creates a list of Calendars to create a Schedule
   <Stick> is used to stick the Schedule Header to the Schedule
   to track horizontal scrolling.
 */
-export const Schedule = ({ calendarHeaders, ...calendarOptions }: Schedule) => {
+export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }: Schedule) => {
   const times = {
     slotMaxTime: calendarOptions.slotMaxTime as string,
     slotMinTime: calendarOptions.slotMinTime as string,
   };
-  const events = calendarOptions?.events as EventInput[];
   const {
     appState: { selectedTerm },
   } = useContext(AppContext);
@@ -34,15 +35,13 @@ export const Schedule = ({ calendarHeaders, ...calendarOptions }: Schedule) => {
           <Stick node={<ScheduleHeader headers={calendarHeaders} />} position="top left">
             <div className="adjacent">
               {calendarHeaders.map((header) => {
-                const calendarEvents = events?.filter((e) => {
-                  return (
-                    header === e.extendedProps?.header &&
-                    e.extendedProps?.section.term === selectedTerm
-                  );
+                const groupEvents = groupedEvents[header];
+                const groupEventsInTerm = groupEvents.filter((e) => {
+                  return e.extendedProps?.section.term === selectedTerm;
                 });
                 return (
                   <div key={header} className="calendar-width hide-axis">
-                    <Calendar {...calendarOptions} key={header} events={calendarEvents} />
+                    <Calendar {...calendarOptions} key={header} events={groupEventsInTerm} />
                   </div>
                 );
               })}

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -29,6 +29,7 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
     slotMinTime,
   };
 
+  // Add context times to the existing calendarOptions
   calendarOptions = {
     ...calendarOptions,
     ...times,

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -20,14 +20,20 @@ interface Schedule extends CalendarOptions {
   to track horizontal scrolling.
 */
 export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }: Schedule) => {
-  // TODO: Limit times to the min and max time of events by default
-  const times = {
-    slotMaxTime: calendarOptions.slotMaxTime as string,
-    slotMinTime: calendarOptions.slotMinTime as string,
-  };
   const {
-    appState: { selectedTerm },
+    appState: { selectedTerm, slotMaxTime, slotMinTime },
   } = useContext(AppContext);
+
+  const times = {
+    slotMaxTime,
+    slotMinTime,
+  };
+
+  calendarOptions = {
+    ...calendarOptions,
+    slotMaxTime,
+    slotMinTime,
+  };
 
   // Filter out events from other terms
   forOwn(groupedEvents, (_, key) => {

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -31,8 +31,7 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
 
   calendarOptions = {
     ...calendarOptions,
-    slotMaxTime,
-    slotMinTime,
+    ...times,
   };
 
   // Filter out events from other terms
@@ -42,7 +41,7 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
     });
   });
 
-  // Filter out headers (and calendars) with no events
+  // Filter out headers with no events
   const calendarHeadersNoEmptyInTerm = filter(calendarHeaders, (header) => {
     const groupEvents = groupedEvents[header];
     return groupEvents?.length > 0;

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -1,8 +1,8 @@
 import { CalendarOptions, EventInput } from "@fullcalendar/react";
-import React from "react";
+import React, { useContext } from "react";
 import Stick from "react-stick";
 import StickyNode from "react-stickynode";
-import { Term } from "../../../utilities/interfaces/dataInterfaces";
+import { AppContext } from "../../../utilities/services/appContext";
 import { getHoursArr } from "../../../utilities/services/schedule";
 import { ScheduleToolbar } from "../../Toolbar/ScheduleToolbar";
 import { Calendar } from "../Calendar";
@@ -22,6 +22,9 @@ export const Schedule = ({ calendarHeaders, ...calendarOptions }: Schedule) => {
     slotMinTime: calendarOptions.slotMinTime as string,
   };
   const events = calendarOptions?.events as EventInput[];
+  const {
+    appState: { selectedTerm },
+  } = useContext(AppContext);
   return (
     <>
       <ScheduleToolbar />
@@ -34,7 +37,7 @@ export const Schedule = ({ calendarHeaders, ...calendarOptions }: Schedule) => {
                 const calendarEvents = events?.filter((e) => {
                   return (
                     header === e.extendedProps?.header &&
-                    e.extendedProps?.section.term === Term.Fall
+                    e.extendedProps?.section.term === selectedTerm
                   );
                 });
                 return (

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -1,5 +1,5 @@
 import { CalendarOptions } from "@fullcalendar/react";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useMemo } from "react";
 import Stick from "react-stick";
 import StickyNode from "react-stickynode";
 import { AppContext } from "../../../utilities/services/appContext";
@@ -39,17 +39,14 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
     ...times,
   };
 
-  const [filteredEvents, setFilteredEvents] = useState(groupedEvents);
-  const [filteredHeaders, setFilteredHeaders] = useState(calendarHeaders);
-
   // Filter out events from other terms
-  useEffect(() => {
-    setFilteredEvents(filterEventsByTerm(groupedEvents, selectedTerm));
+  const filteredEvents = useMemo(() => {
+    return filterEventsByTerm(groupedEvents, selectedTerm);
   }, [groupedEvents, selectedTerm]);
 
   // Filter out headers with no events
-  useEffect(() => {
-    setFilteredHeaders(filterHeadersWithNoEvents(filteredEvents, calendarHeaders));
+  const calenderHeadersNoEmptyInTerm = useMemo(() => {
+    return filterHeadersWithNoEvents(filteredEvents, calendarHeaders);
   }, [filteredEvents, calendarHeaders]);
 
   return (
@@ -58,9 +55,12 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
       <div className="schedule-time-axis-wrapper">
         <LeftTimeAxis {...times} />
         <div className="schedule-wrapper">
-          <Stick node={<ScheduleHeader headers={filteredHeaders} />} position="top left">
+          <Stick
+            node={<ScheduleHeader headers={calenderHeadersNoEmptyInTerm} />}
+            position="top left"
+          >
             <div className="adjacent">
-              {filteredHeaders.map((header) => {
+              {calenderHeadersNoEmptyInTerm.map((header) => {
                 return (
                   <div key={header} className="calendar-width hide-axis">
                     <Calendar {...calendarOptions} key={header} events={filteredEvents[header]} />

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -1,7 +1,8 @@
-import { CalendarOptions } from "@fullcalendar/react";
+import { CalendarOptions, EventInput } from "@fullcalendar/react";
 import React from "react";
 import Stick from "react-stick";
 import StickyNode from "react-stickynode";
+import { Term } from "../../../utilities/interfaces/dataInterfaces";
 import { getHoursArr } from "../../../utilities/services/schedule";
 import { ScheduleToolbar } from "../../Toolbar/ScheduleToolbar";
 import { Calendar } from "../Calendar";
@@ -20,6 +21,7 @@ export const Schedule = ({ calendarHeaders, ...calendarOptions }: Schedule) => {
     slotMaxTime: calendarOptions.slotMaxTime as string,
     slotMinTime: calendarOptions.slotMinTime as string,
   };
+  const events = calendarOptions?.events as EventInput[];
   return (
     <>
       <ScheduleToolbar />
@@ -29,9 +31,15 @@ export const Schedule = ({ calendarHeaders, ...calendarOptions }: Schedule) => {
           <Stick node={<ScheduleHeader headers={calendarHeaders} />} position="top left">
             <div className="adjacent">
               {calendarHeaders.map((header) => {
+                const calendarEvents = events?.filter((e) => {
+                  return (
+                    header === e.extendedProps?.header &&
+                    e.extendedProps?.section.term === Term.Fall
+                  );
+                });
                 return (
                   <div key={header} className="calendar-width hide-axis">
-                    <Calendar {...calendarOptions} key={header} />
+                    <Calendar {...calendarOptions} key={header} events={calendarEvents} />
                   </div>
                 );
               })}

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -19,6 +19,7 @@ interface Schedule extends CalendarOptions {
   to track horizontal scrolling.
 */
 export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }: Schedule) => {
+  // TODO: Limit times to the min and max time of events by default
   const times = {
     slotMaxTime: calendarOptions.slotMaxTime as string,
     slotMinTime: calendarOptions.slotMinTime as string,
@@ -34,6 +35,7 @@ export const Schedule = ({ calendarHeaders, groupedEvents, ...calendarOptions }:
         <div className="schedule-wrapper">
           <Stick node={<ScheduleHeader headers={calendarHeaders} />} position="top left">
             <div className="adjacent">
+              {/* TODO: Remove calendars with no events */}
               {calendarHeaders.map((header) => {
                 const groupEvents = groupedEvents[header];
                 const groupEventsInTerm = groupEvents.filter((e) => {

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -32,7 +32,6 @@ const pruimSpreadsheetFields: ValidFields = {
   year: cf.yearCase,
 };
 
-// TODO: parse duration and semester length
 const registrarSpreadsheetFields: ValidFields = {
   AcademicYear: cf.yearCase,
   BuildingAndRoom: cf.locationCase,

--- a/client-course-schedulizer/src/utilities/helpers/utils.ts
+++ b/client-course-schedulizer/src/utilities/helpers/utils.ts
@@ -1,0 +1,5 @@
+export const enumArray = <T>(e: T) => {
+  return Object.keys(e).map((val) => {
+    return e[val as keyof typeof e];
+  });
+};

--- a/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
@@ -5,6 +5,8 @@ export interface AppState {
   professors: string[];
   schedule: Schedule;
   selectedTerm: Term;
+  slotMaxTime: string;
+  slotMinTime: string;
 }
 
 // Defaults for the app state when it launches
@@ -12,6 +14,8 @@ export const initialAppState = {
   professors: [],
   schedule: { courses: [] },
   selectedTerm: Term.Fall,
+  slotMaxTime: "22:00",
+  slotMinTime: "6:00",
 };
 
 // structure of actions that can be sent to app dispatch

--- a/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
@@ -1,23 +1,24 @@
-import { Schedule } from "./dataInterfaces";
+import { Schedule, Term } from "./dataInterfaces";
 
 // structure for the global app state
 export interface AppState {
-  isLoading: boolean;
   professors: string[];
   schedule: Schedule;
+  selectedTerm: Term;
 }
 
 // Defaults for the app state when it launches
 export const initialAppState = {
-  isLoading: false,
   professors: [],
   schedule: { courses: [] },
+  selectedTerm: Term.Fall,
 };
 
 // structure of actions that can be sent to app dispatch
 export interface AppAction {
   payload: {
-    schedule: Schedule;
+    schedule?: Schedule;
+    term?: Term;
   };
-  type: "setScheduleData"; // add | to add more actions in the future
+  type: "setScheduleData" | "setSelectedTerm"; // add | to add more actions in the future
 }

--- a/client-course-schedulizer/src/utilities/services/appReducer.ts
+++ b/client-course-schedulizer/src/utilities/services/appReducer.ts
@@ -15,8 +15,8 @@ export const reducer = (state: AppState, action: AppAction) => {
       schedule = schedule || { courses: [] };
       const sections: Section[] = flatten(map(schedule.courses, "sections"));
       const meetings: Meeting[] = flatten(map(sections, "meetings"));
-      const startTimes = map(map(meetings, "startTime"), (time) => {
-        return moment(time, "h:mma");
+      const startTimes = map(meetings, (meeting) => {
+        return moment(meeting.startTime, "h:mma");
       });
       const endTimes = map(meetings, (meeting) => {
         return moment(meeting.startTime, "h:mma").add(meeting.duration, "minutes");

--- a/client-course-schedulizer/src/utilities/services/appReducer.ts
+++ b/client-course-schedulizer/src/utilities/services/appReducer.ts
@@ -1,4 +1,5 @@
 import { AppAction, AppState } from "../interfaces/appInterfaces";
+import { Term } from "../interfaces/dataInterfaces";
 import { getProfs } from "./facultySchedule";
 
 /*
@@ -8,8 +9,14 @@ import { getProfs } from "./facultySchedule";
 export const reducer = (state: AppState, action: AppAction) => {
   switch (action.type) {
     case "setScheduleData": {
-      const { schedule } = action.payload;
+      let { schedule } = action.payload;
+      schedule = schedule || { courses: [] };
       return { ...state, professors: getProfs(schedule), schedule };
+    }
+    case "setSelectedTerm": {
+      let { term } = action.payload;
+      term = term || Term.Fall;
+      return { ...state, selectedTerm: term };
     }
     default:
       return state;

--- a/client-course-schedulizer/src/utilities/services/appReducer.ts
+++ b/client-course-schedulizer/src/utilities/services/appReducer.ts
@@ -1,8 +1,7 @@
-import { flatten, map, maxBy, minBy } from "lodash";
-import moment from "moment";
 import { AppAction, AppState } from "../interfaces/appInterfaces";
-import { Meeting, Section, Term } from "../interfaces/dataInterfaces";
+import { Term } from "../interfaces/dataInterfaces";
 import { getProfs } from "./facultySchedule";
+import { getMinAndMaxTimes } from "./schedule";
 
 /*
   Provides a function to perform multiple setState updates
@@ -13,17 +12,14 @@ export const reducer = (state: AppState, action: AppAction) => {
     case "setScheduleData": {
       let { schedule } = action.payload;
       schedule = schedule || { courses: [] };
-      const sections: Section[] = flatten(map(schedule.courses, "sections"));
-      const meetings: Meeting[] = flatten(map(sections, "meetings"));
-      const startTimes = map(meetings, (meeting) => {
-        return moment(meeting.startTime, "h:mma");
-      });
-      const endTimes = map(meetings, (meeting) => {
-        return moment(meeting.startTime, "h:mma").add(meeting.duration, "minutes");
-      });
-      const slotMinTime = minBy(startTimes)?.format("HH:mm") || "6:00";
-      const slotMaxTime = maxBy(endTimes)?.format("HH:mm") || "22:00";
-      return { ...state, professors: getProfs(schedule), schedule, slotMaxTime, slotMinTime };
+      const times = getMinAndMaxTimes(schedule);
+      return {
+        ...state,
+        professors: getProfs(schedule),
+        schedule,
+        slotMaxTime: times.maxTime,
+        slotMinTime: times.minTime,
+      };
     }
     case "setSelectedTerm": {
       let { term } = action.payload;

--- a/client-course-schedulizer/src/utilities/services/facultySchedule.ts
+++ b/client-course-schedulizer/src/utilities/services/facultySchedule.ts
@@ -1,8 +1,5 @@
-import { EventInput } from "@fullcalendar/react";
 import forEach from "lodash/forEach";
-import moment from "moment";
-import { initialDate } from "../../components/reuseables/Calendar";
-import { Day, Schedule } from "../interfaces/dataInterfaces";
+import { Schedule } from "../interfaces/dataInterfaces";
 
 // Get list of unique professors.
 export const getProfs = (schedule: Schedule): string[] => {
@@ -15,40 +12,4 @@ export const getProfs = (schedule: Schedule): string[] => {
     });
   });
   return [...professorsSet];
-};
-
-export const getFacultyEvents = (schedule: Schedule): EventInput[] => {
-  const events: EventInput[] = [];
-  const days: Day[] = Object.keys(Day).map((day) => {
-    return Day[day as keyof typeof Day];
-  });
-  forEach(schedule.courses, (course) => {
-    forEach(course.sections, (section) => {
-      forEach(section.instructors, (prof) => {
-        forEach(section.meetings, (meeting) => {
-          forEach(meeting.days, (day) => {
-            const startTimeMoment = moment(meeting.startTime, "h:mma");
-            const endTimeMoment = moment(startTimeMoment).add(meeting.duration, "minutes");
-            const dayOfWeek = moment(initialDate)
-              .add(days.indexOf(day) + 1, "days")
-              .format("YYYY-MM-DD");
-            const sectionName = `${course.prefixes[0]}-${course.number}-${section.letter}`;
-            events.push({
-              description: course.name,
-              end: `${dayOfWeek}T${endTimeMoment.format("HH:mm")}`,
-              extendedProps: {
-                course,
-                header: prof,
-                meeting,
-                section,
-              },
-              start: `${dayOfWeek}T${startTimeMoment.format("HH:mm")}`,
-              title: sectionName,
-            });
-          });
-        });
-      });
-    });
-  });
-  return events;
 };

--- a/client-course-schedulizer/src/utilities/services/facultySchedule.ts
+++ b/client-course-schedulizer/src/utilities/services/facultySchedule.ts
@@ -1,5 +1,8 @@
+import { EventInput } from "@fullcalendar/react";
 import forEach from "lodash/forEach";
-import { Schedule } from "../interfaces/dataInterfaces";
+import moment from "moment";
+import { initialDate } from "../../components/reuseables/Calendar";
+import { Day, Schedule } from "../interfaces/dataInterfaces";
 
 // Get list of unique professors.
 export const getProfs = (schedule: Schedule): string[] => {
@@ -12,4 +15,39 @@ export const getProfs = (schedule: Schedule): string[] => {
     });
   });
   return [...professorsSet];
+};
+
+export const getFacultyEvents = (schedule: Schedule): EventInput[] => {
+  const events: EventInput[] = [];
+  const days: Day[] = Object.keys(Day).map((day) => {
+    return Day[day as keyof typeof Day];
+  });
+  forEach(schedule.courses, (course) => {
+    forEach(course.sections, (section) => {
+      forEach(section.instructors, (prof) => {
+        forEach(section.meetings, (meeting) => {
+          forEach(meeting.days, (day) => {
+            const startTimeMoment = moment(meeting.startTime, "h:mma");
+            const endTimeMoment = moment(startTimeMoment).add(meeting.duration, "minutes");
+            const dayOfWeekMoment = moment(initialDate)
+              .add(days.indexOf(day) + 1, "days")
+              .format("YYYY-MM-DD");
+            const sectionName = `${course.prefixes[0]}-${course.number}-${section.letter}`;
+            events.push({
+              description: course.name,
+              end: `${dayOfWeekMoment}T${endTimeMoment.format("HH:mm")}`,
+              extendedProps: {
+                course,
+                header: prof,
+                section,
+              },
+              start: `${dayOfWeekMoment}T${startTimeMoment.format("HH:mm")}`,
+              title: sectionName,
+            });
+          });
+        });
+      });
+    });
+  });
+  return events;
 };

--- a/client-course-schedulizer/src/utilities/services/facultySchedule.ts
+++ b/client-course-schedulizer/src/utilities/services/facultySchedule.ts
@@ -29,19 +29,20 @@ export const getFacultyEvents = (schedule: Schedule): EventInput[] => {
           forEach(meeting.days, (day) => {
             const startTimeMoment = moment(meeting.startTime, "h:mma");
             const endTimeMoment = moment(startTimeMoment).add(meeting.duration, "minutes");
-            const dayOfWeekMoment = moment(initialDate)
+            const dayOfWeek = moment(initialDate)
               .add(days.indexOf(day) + 1, "days")
               .format("YYYY-MM-DD");
             const sectionName = `${course.prefixes[0]}-${course.number}-${section.letter}`;
             events.push({
               description: course.name,
-              end: `${dayOfWeekMoment}T${endTimeMoment.format("HH:mm")}`,
+              end: `${dayOfWeek}T${endTimeMoment.format("HH:mm")}`,
               extendedProps: {
                 course,
                 header: prof,
+                meeting,
                 section,
               },
-              start: `${dayOfWeekMoment}T${startTimeMoment.format("HH:mm")}`,
+              start: `${dayOfWeek}T${startTimeMoment.format("HH:mm")}`,
               title: sectionName,
             });
           });

--- a/client-course-schedulizer/src/utilities/services/schedule.ts
+++ b/client-course-schedulizer/src/utilities/services/schedule.ts
@@ -1,9 +1,9 @@
 import { EventInput } from "@fullcalendar/react";
-import { forEach } from "lodash";
+import { flatten, forEach, map, maxBy, minBy } from "lodash";
 import range from "lodash/range";
 import moment from "moment";
 import { initialDate } from "../../components/reuseables/Calendar";
-import { Day, Schedule } from "../interfaces/dataInterfaces";
+import { Day, Meeting, Schedule, Section } from "../interfaces/dataInterfaces";
 
 // Returns a list of hours to display on the Schedule
 // TODO: add better types for timing, maybe: https://stackoverflow.com/questions/51445767/how-to-define-a-regex-matched-string-type-in-typescript
@@ -58,4 +58,21 @@ export const getEvents = (schedule: Schedule, groups: "faculty" | "room"): Group
     });
   });
   return events;
+};
+
+export const getMinAndMaxTimes = (schedule: Schedule) => {
+  const sections: Section[] = flatten(map(schedule.courses, "sections"));
+  const meetings: Meeting[] = flatten(map(sections, "meetings"));
+  const startTimes = map(meetings, (meeting) => {
+    return moment(meeting.startTime, "h:mma");
+  });
+  const endTimes = map(meetings, (meeting) => {
+    return moment(meeting.startTime, "h:mma").add(meeting.duration, "minutes");
+  });
+  const minTime = minBy(startTimes)?.format("HH:mm") || "6:00";
+  const maxTime = maxBy(endTimes)?.format("HH:mm") || "22:00";
+  return {
+    maxTime,
+    minTime,
+  };
 };

--- a/client-course-schedulizer/src/utilities/services/schedule.ts
+++ b/client-course-schedulizer/src/utilities/services/schedule.ts
@@ -17,6 +17,7 @@ export interface GroupedEvents {
   [key: string]: EventInput[];
 }
 
+// TODO: Add events with no meeting times as all day
 export const getEvents = (schedule: Schedule, groups: "faculty" | "room"): GroupedEvents => {
   const events: GroupedEvents = {};
   const days: Day[] = Object.keys(Day).map((day) => {

--- a/client-course-schedulizer/src/utilities/services/schedule.ts
+++ b/client-course-schedulizer/src/utilities/services/schedule.ts
@@ -1,10 +1,10 @@
 import { EventInput } from "@fullcalendar/react";
-import { flatten, forEach, map, maxBy, minBy } from "lodash";
+import { filter, flatten, forEach, forOwn, map, maxBy, minBy } from "lodash";
 import range from "lodash/range";
 import moment from "moment";
 import { initialDate } from "../../components/reuseables/Calendar";
 import { enumArray } from "../helpers/utils";
-import { Day, Meeting, Schedule, Section } from "../interfaces/dataInterfaces";
+import { Day, Meeting, Schedule, Section, Term } from "../interfaces/dataInterfaces";
 
 // Returns a list of hours to display on the Schedule
 // TODO: add better types for timing, maybe: https://stackoverflow.com/questions/51445767/how-to-define-a-regex-matched-string-type-in-typescript
@@ -74,4 +74,21 @@ export const getMinAndMaxTimes = (schedule: Schedule) => {
     maxTime,
     minTime,
   };
+};
+
+export const filterEventsByTerm = (groupedEvents: GroupedEvents, term: Term) => {
+  const tempGroupedEvents: GroupedEvents = {};
+  forOwn(groupedEvents, (_, key) => {
+    tempGroupedEvents[key] = filter(groupedEvents[key], (e) => {
+      return e.extendedProps?.section.term === term;
+    });
+  });
+  return tempGroupedEvents;
+};
+
+export const filterHeadersWithNoEvents = (filteredEvents: GroupedEvents, headers: string[]) => {
+  return filter(headers, (header) => {
+    const groupEvents = filteredEvents[header];
+    return groupEvents?.length > 0;
+  });
 };

--- a/client-course-schedulizer/src/utilities/services/schedule.ts
+++ b/client-course-schedulizer/src/utilities/services/schedule.ts
@@ -1,4 +1,9 @@
+import { EventInput } from "@fullcalendar/react";
+import { forEach } from "lodash";
 import range from "lodash/range";
+import moment from "moment";
+import { initialDate } from "../../components/reuseables/Calendar";
+import { Day, Schedule } from "../interfaces/dataInterfaces";
 
 // Returns a list of hours to display on the Schedule
 // TODO: add better types for timing, maybe: https://stackoverflow.com/questions/51445767/how-to-define-a-regex-matched-string-type-in-typescript
@@ -6,4 +11,50 @@ export const getHoursArr = (min: string, max: string): number[] => {
   const minHour = parseInt(min.split(":")[0]);
   const maxHour = parseInt(max.split(":")[0]);
   return range(minHour, maxHour);
+};
+
+export interface GroupedEvents {
+  [key: string]: EventInput[];
+}
+
+export const getEvents = (schedule: Schedule, groups: "faculty" | "room"): GroupedEvents => {
+  const events: GroupedEvents = {};
+  const days: Day[] = Object.keys(Day).map((day) => {
+    return Day[day as keyof typeof Day];
+  });
+  forEach(schedule.courses, (course) => {
+    forEach(course.sections, (section) => {
+      forEach(section.instructors, (prof) => {
+        forEach(section.meetings, (meeting) => {
+          forEach(meeting.days, (day) => {
+            const startTimeMoment = moment(meeting.startTime, "h:mma");
+            const endTimeMoment = moment(startTimeMoment).add(meeting.duration, "minutes");
+            const dayOfWeek = moment(initialDate)
+              .add(days.indexOf(day) + 1, "days")
+              .format("YYYY-MM-DD");
+            const sectionName = `${course.prefixes[0]}-${course.number}-${section.letter}`;
+            const room = `${meeting.location.building} ${meeting.location.roomNumber}`;
+            const group = groups === "faculty" ? prof : room;
+            const newEvent: EventInput = {
+              description: course.name,
+              end: `${dayOfWeek}T${endTimeMoment.format("HH:mm")}`,
+              extendedProps: {
+                course,
+                meeting,
+                section,
+              },
+              start: `${dayOfWeek}T${startTimeMoment.format("HH:mm")}`,
+              title: sectionName,
+            };
+            if (events[group]) {
+              events[group].push(newEvent);
+            } else {
+              events[group] = [newEvent];
+            }
+          });
+        });
+      });
+    });
+  });
+  return events;
 };


### PR DESCRIPTION
This PR adds events to the calendars and allows you to scroll through semesters. It does so by creating a `GroupedEvents` objects which groups events by the faculty member and then loads the events on their calendar.