### PR TITLE
Allow multiple meetings

### DIFF
--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
@@ -82,7 +82,7 @@ export const AddSectionPopover = () => {
   const {
     appState: { schedule },
     appDispatch,
-    setIsLoading,
+    setIsCSVLoading,
   } = useContext(AppContext);
 
   const spacing = 4;
@@ -102,7 +102,7 @@ export const AddSectionPopover = () => {
   const [semesterLength, setSemesterLength] = useState("full");
 
   const onSubmit = (data: SectionInput) => {
-    setIsLoading(true);
+    setIsCSVLoading(true);
     const location = locationCase(data.location);
     const semesterType = convertToSemesterLength(
       data.intensive || data.half || data.semesterLength,
@@ -147,7 +147,7 @@ export const AddSectionPopover = () => {
     insertSectionCourse(schedule, newSection, newCourse);
 
     appDispatch({ payload: { schedule }, type: "setScheduleData" });
-    setIsLoading(false);
+    setIsCSVLoading(false);
   };
   const onSemesterLengthChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSemesterLength(e.target.value);

--- a/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
+++ b/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
@@ -27,10 +27,9 @@ const thursReg = RegExp("[Tt][Hh]|[Rr]");
 const friReg = RegExp("[Ff]");
 const satReg = RegExp("[Ss](?![Uu])");
 
-export const startTimeCallback = (value: string, { meetings }: CaseCallbackParams) => {
-  const startTimes = value.split("\n");
-  let i = 0;
-  startTimes.forEach((startTime) => {
+const createMeetings = (value: string, { meetings }: CaseCallbackParams): string[] => {
+  const valueParts = value.split("\n");
+  for (let i = 0; i < valueParts.length; i += 1) {
     if (meetings.length <= i) {
       // If there aren't enough meetings, create a new one
       meetings.push({
@@ -40,26 +39,23 @@ export const startTimeCallback = (value: string, { meetings }: CaseCallbackParam
         startTime: "",
       });
     }
+  }
+  return valueParts;
+};
+
+export const startTimeCallback = (value: string, params: CaseCallbackParams) => {
+  const startTimes = createMeetings(value, params);
+  const { meetings } = params;
+  startTimes.forEach((startTime, i) => {
     meetings[i].startTime = startTimeCase(startTime);
-    i += 1;
   });
 };
 
-export const locationCallback = (value: string, { meetings }: CaseCallbackParams) => {
-  const locations = value.split("\n");
-  let i = 0;
-  locations.forEach((location) => {
-    if (meetings.length <= i) {
-      // If there aren't enough meetings, create a new one
-      meetings.push({
-        days: [],
-        duration: 0,
-        location: { building: "", roomCapacity: 0, roomNumber: "" },
-        startTime: "",
-      });
-    }
+export const locationCallback = (value: string, params: CaseCallbackParams) => {
+  const locations = createMeetings(value, params);
+  const { meetings } = params;
+  locations.forEach((location, i) => {
     [meetings[i].location.building, meetings[i].location.roomNumber] = locationCase(location);
-    i += 1;
   });
 };
 
@@ -71,21 +67,11 @@ export const semesterLengthCallback = (value: string, { section }: CaseCallbackP
   section.semesterLength = semesterLengthCase(value);
 };
 
-export const daysCallback = (value: string, { meetings }: CaseCallbackParams) => {
-  const daysStrings = value.split("\n");
-  let i = 0;
-  daysStrings.forEach((days) => {
-    if (meetings.length <= i) {
-      // If there aren't enough meetings, create a new one
-      meetings.push({
-        days: [],
-        duration: 0,
-        location: { building: "", roomCapacity: 0, roomNumber: "" },
-        startTime: "",
-      });
-    }
+export const daysCallback = (value: string, params: CaseCallbackParams) => {
+  const daysStrings = createMeetings(value, params);
+  const { meetings } = params;
+  daysStrings.forEach((days, i) => {
     meetings[i].days = daysCase(days);
-    i += 1;
   });
 };
 
@@ -137,39 +123,19 @@ export const facultyHoursCallback = (value: string, { course }: CaseCallbackPara
   course.facultyHours = numberDefaultZeroCase(value);
 };
 
-export const durationCallback = (value: string, { meetings }: CaseCallbackParams) => {
-  const durations = value.split("\n");
-  let i = 0;
-  durations.forEach((duration) => {
-    if (meetings.length <= i) {
-      // If there aren't enough meetings, create a new one
-      meetings.push({
-        days: [],
-        duration: 0,
-        location: { building: "", roomCapacity: 0, roomNumber: "" },
-        startTime: "",
-      });
-    }
+export const durationCallback = (value: string, params: CaseCallbackParams) => {
+  const durations = createMeetings(value, params);
+  const { meetings } = params;
+  durations.forEach((duration, i) => {
     meetings[i].duration = durationCase(duration);
-    i += 1;
   });
 };
 
-export const roomCapacityCallback = (value: string, { meetings }: CaseCallbackParams) => {
-  const capacities = value.split("\n");
-  let i = 0;
-  capacities.forEach((capacity) => {
-    if (meetings.length <= i) {
-      // If there aren't enough meetings, create a new one
-      meetings.push({
-        days: [],
-        duration: 0,
-        location: { building: "", roomCapacity: 0, roomNumber: "" },
-        startTime: "",
-      });
-    }
+export const roomCapacityCallback = (value: string, params: CaseCallbackParams) => {
+  const capacities = createMeetings(value, params);
+  const { meetings } = params;
+  capacities.forEach((capacity, i) => {
     meetings[i].location.roomCapacity = numberDefaultZeroCase(capacity);
-    i += 1;
   });
 };
 

--- a/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
+++ b/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
@@ -29,7 +29,7 @@ const satReg = RegExp("[Ss](?![Uu])");
 
 const createMeetings = (value: string, { meetings }: CaseCallbackParams): string[] => {
   const valueParts = value.split("\n");
-  for (let i = 0; i < valueParts.length; i += 1) {
+  valueParts.forEach((_, i) => {
     if (meetings.length <= i) {
       // If there aren't enough meetings, create a new one
       meetings.push({
@@ -39,22 +39,30 @@ const createMeetings = (value: string, { meetings }: CaseCallbackParams): string
         startTime: "",
       });
     }
-  }
+  });
   return valueParts;
 };
 
-export const startTimeCallback = (value: string, params: CaseCallbackParams) => {
-  const startTimes = createMeetings(value, params);
+const assignWithMeetings = (
+  value: string,
+  params: CaseCallbackParams,
+  arrAssign: (value: string, i: number, arr: Meeting[]) => void,
+) => {
+  const valueParts = createMeetings(value, params);
   const { meetings } = params;
-  startTimes.forEach((startTime, i) => {
+  valueParts.forEach((v, i) => {
+    arrAssign(v, i, meetings);
+  });
+};
+
+export const startTimeCallback = (value: string, params: CaseCallbackParams) => {
+  assignWithMeetings(value, params, (startTime, i, meetings) => {
     meetings[i].startTime = startTimeCase(startTime);
   });
 };
 
 export const locationCallback = (value: string, params: CaseCallbackParams) => {
-  const locations = createMeetings(value, params);
-  const { meetings } = params;
-  locations.forEach((location, i) => {
+  assignWithMeetings(value, params, (location, i, meetings) => {
     [meetings[i].location.building, meetings[i].location.roomNumber] = locationCase(location);
   });
 };
@@ -68,9 +76,7 @@ export const semesterLengthCallback = (value: string, { section }: CaseCallbackP
 };
 
 export const daysCallback = (value: string, params: CaseCallbackParams) => {
-  const daysStrings = createMeetings(value, params);
-  const { meetings } = params;
-  daysStrings.forEach((days, i) => {
+  assignWithMeetings(value, params, (days, i, meetings) => {
     meetings[i].days = daysCase(days);
   });
 };
@@ -124,17 +130,13 @@ export const facultyHoursCallback = (value: string, { course }: CaseCallbackPara
 };
 
 export const durationCallback = (value: string, params: CaseCallbackParams) => {
-  const durations = createMeetings(value, params);
-  const { meetings } = params;
-  durations.forEach((duration, i) => {
+  assignWithMeetings(value, params, (duration, i, meetings) => {
     meetings[i].duration = durationCase(duration);
   });
 };
 
 export const roomCapacityCallback = (value: string, params: CaseCallbackParams) => {
-  const capacities = createMeetings(value, params);
-  const { meetings } = params;
-  capacities.forEach((capacity, i) => {
+  assignWithMeetings(value, params, (capacity, i, meetings) => {
     meetings[i].location.roomCapacity = numberDefaultZeroCase(capacity);
   });
 };

--- a/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
+++ b/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
@@ -3,7 +3,7 @@ import { Course, Day, Meeting, Section, SemesterLength, Term } from "../interfac
 
 export interface CaseCallbackParams {
   course: Course;
-  firstMeeting: Meeting;
+  meetings: Meeting[];
   section: Section;
 }
 
@@ -24,12 +24,40 @@ const thursReg = RegExp("[Tt][Hh]|[Rr]");
 const friReg = RegExp("[Ff]");
 const satReg = RegExp("[Ss](?![Uu])");
 
-export const startTimeCallback = (value: string, { firstMeeting }: CaseCallbackParams) => {
-  firstMeeting.startTime = startTimeCase(value);
+export const startTimeCallback = (value: string, { meetings }: CaseCallbackParams) => {
+  const startTimes = value.split("\n");
+  let i = 0;
+  startTimes.forEach((startTime) => {
+    if (meetings.length <= i) {
+      // If there aren't enough meetings, create a new one
+      meetings.push({
+        days: [],
+        duration: 0,
+        location: { building: "", roomCapacity: 0, roomNumber: "" },
+        startTime: "",
+      });
+    }
+    meetings[i].startTime = startTimeCase(startTime);
+    i += 1;
+  });
 };
 
-export const locationCallback = (value: string, { firstMeeting }: CaseCallbackParams) => {
-  [firstMeeting.location.building, firstMeeting.location.roomNumber] = locationCase(value);
+export const locationCallback = (value: string, { meetings }: CaseCallbackParams) => {
+  const locations = value.split("\n");
+  let i = 0;
+  locations.forEach((location) => {
+    if (meetings.length <= i) {
+      // If there aren't enough meetings, create a new one
+      meetings.push({
+        days: [],
+        duration: 0,
+        location: { building: "", roomCapacity: 0, roomNumber: "" },
+        startTime: "",
+      });
+    }
+    [meetings[i].location.building, meetings[i].location.roomNumber] = locationCase(location);
+    i += 1;
+  });
 };
 
 export const termCallback = (value: string, { section }: CaseCallbackParams) => {
@@ -40,8 +68,22 @@ export const semesterLengthCallback = (value: string, { section }: CaseCallbackP
   section.semesterLength = semesterLengthCase(value);
 };
 
-export const daysCallback = (value: string, { firstMeeting }: CaseCallbackParams) => {
-  firstMeeting.days = daysCase(value);
+export const daysCallback = (value: string, { meetings }: CaseCallbackParams) => {
+  const daysStrings = value.split("\n");
+  let i = 0;
+  daysStrings.forEach((days) => {
+    if (meetings.length <= i) {
+      // If there aren't enough meetings, create a new one
+      meetings.push({
+        days: [],
+        duration: 0,
+        location: { building: "", roomCapacity: 0, roomNumber: "" },
+        startTime: "",
+      });
+    }
+    meetings[i].days = daysCase(days);
+    i += 1;
+  });
 };
 
 export const instructorCallback = (value: string, { section }: CaseCallbackParams) => {
@@ -92,12 +134,40 @@ export const facultyHoursCallback = (value: string, { course }: CaseCallbackPara
   course.facultyHours = numberDefaultZeroCase(value);
 };
 
-export const durationCallback = (value: string, { firstMeeting }: CaseCallbackParams) => {
-  firstMeeting.duration = durationCase(value);
+export const durationCallback = (value: string, { meetings }: CaseCallbackParams) => {
+  const durations = value.split("\n");
+  let i = 0;
+  durations.forEach((duration) => {
+    if (meetings.length <= i) {
+      // If there aren't enough meetings, create a new one
+      meetings.push({
+        days: [],
+        duration: 0,
+        location: { building: "", roomCapacity: 0, roomNumber: "" },
+        startTime: "",
+      });
+    }
+    meetings[i].duration = durationCase(duration);
+    i += 1;
+  });
 };
 
-export const roomCapacityCallback = (value: string, { firstMeeting }: CaseCallbackParams) => {
-  firstMeeting.location.roomCapacity = numberDefaultZeroCase(value);
+export const roomCapacityCallback = (value: string, { meetings }: CaseCallbackParams) => {
+  const capacities = value.split("\n");
+  let i = 0;
+  capacities.forEach((capacity) => {
+    if (meetings.length <= i) {
+      // If there aren't enough meetings, create a new one
+      meetings.push({
+        days: [],
+        duration: 0,
+        location: { building: "", roomCapacity: 0, roomNumber: "" },
+        startTime: "",
+      });
+    }
+    meetings[i].location.roomCapacity = numberDefaultZeroCase(capacity);
+    i += 1;
+  });
 };
 
 export const sectionStartCallback = (value: string, { section }: CaseCallbackParams) => {

--- a/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
+++ b/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
@@ -273,6 +273,8 @@ export const daysCase = (value: string) => {
 };
 
 export const instructorCase = (value: string): string[] => {
+  // TODO: Instead of splitting at newlines here, instructors should be on a per meeting level
+  //       with newlines separating between the instructor(s) for each meeting (see other meeting relative fields)
   const instructors = value.split(/[;,\n]/);
   return instructors.map((instructor) => {
     return instructor.trim();

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -132,7 +132,7 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
   // TODO: What about TBA meetings where the location is specified but not the time
   //       (currently allowing these causes the app to crash)
   section.meetings = meetings.filter((meeting) => {
-    return meeting.days.length > 0 || meeting.duration > 0;
+    return meeting.days.length > 0 && meeting.duration > 0;
   });
 
   // Check if there is already a course in the schedule with the same prefix and number

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -129,17 +129,11 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
   const { meetings } = section;
 
   // Check if any meetings are empty, and should be removed
-  let i = 0;
-  let numRemoved = 0;
-  const meetingsCopy = meetings;
-  meetings.forEach((meeting) => {
-    if (meeting.days === [] || meeting.duration === 0) {
-      meetingsCopy.splice(i - numRemoved, 1);
-      numRemoved += 1;
-    }
-    i += 1;
+  // TODO: What about TBA meetings where the location is specified but not the time
+  //       (currently allowing these causes the app to crash)
+  section.meetings = meetings.filter((meeting) => {
+    return meeting.days.length > 0 || meeting.duration > 0;
   });
-  section.meetings = meetingsCopy;
 
   // Check if there is already a course in the schedule with the same prefix and number
   const existingCourse: Course[] = schedule.courses.filter((c) => {

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -122,7 +122,6 @@ export const csvStringToSchedule = (csvString: string): Schedule => {
       insertSectionCourse(schedule, section, course);
     }
   });
-  console.log(schedule);
   return schedule;
 };
 

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -163,6 +163,7 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
       const existingSectionIndex = schedule.courses[existingCourseIndex].sections.indexOf(
         existingSection[0],
       );
+      // TODO: Avoid duplicate meetings?
       schedule.courses[existingCourseIndex].sections[
         existingSectionIndex
       ].meetings = schedule.courses[existingCourseIndex].sections[

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -107,7 +107,6 @@ export const csvStringToSchedule = (csvString: string): Schedule => {
       sections: [],
       studentHours: 0,
     };
-    const [firstMeeting] = meetings;
 
     // Iterate through the fields of the CSV, and parse their values for this object
     if (fields) {
@@ -115,23 +114,34 @@ export const csvStringToSchedule = (csvString: string): Schedule => {
         const value = String(object[field]);
         field = field.replace(/\s/g, "");
         if (field in callbacks) {
-          callbacks[field as keyof ValidFields](value, { course, firstMeeting, section });
+          callbacks[field as keyof ValidFields](value, { course, meetings, section });
         }
       });
-
-      // Check if the meeting is empty, and should be removed
-      if (firstMeeting.days === [] || firstMeeting.duration === 0) {
-        section.meetings = [];
-      }
 
       // Insert the Section to the Schedule, either as a new Course or to an existing Course
       insertSectionCourse(schedule, section, course);
     }
   });
+  console.log(schedule);
   return schedule;
 };
 
 export const insertSectionCourse = (schedule: Schedule, section: Section, course: Course) => {
+  const { meetings } = section;
+
+  // Check if any meetings are empty, and should be removed
+  let i = 0;
+  let numRemoved = 0;
+  const meetingsCopy = meetings;
+  meetings.forEach((meeting) => {
+    if (meeting.days === [] || meeting.duration === 0) {
+      meetingsCopy.splice(i - numRemoved, 1);
+      numRemoved += 1;
+    }
+    i += 1;
+  });
+  section.meetings = meetingsCopy;
+
   // Check if there is already a course in the schedule with the same prefix and number
   const existingCourse: Course[] = schedule.courses.filter((c) => {
     return (
@@ -141,10 +151,29 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
     );
   });
 
-  // If there is, add the new section to that course
+  // If there is, first check if there is already a section for that course with the same letter and term
   if (existingCourse.length > 0) {
     const existingCourseIndex = schedule.courses.indexOf(existingCourse[0]);
-    schedule.courses[existingCourseIndex].sections.push(section);
+    const existingSection: Section[] = existingCourse[0].sections.filter((s) => {
+      // TODO: Should we check year and/or semesterLength here as well?
+      return s.letter === section.letter && s.term === section.term;
+    });
+
+    // If there is, add the new meeting(s) to the existing course
+    if (existingSection.length > 0) {
+      const existingSectionIndex = schedule.courses[existingCourseIndex].sections.indexOf(
+        existingSection[0],
+      );
+      schedule.courses[existingCourseIndex].sections[
+        existingSectionIndex
+      ].meetings = schedule.courses[existingCourseIndex].sections[
+        existingSectionIndex
+      ].meetings.concat(section.meetings);
+    }
+    // Otherwise, add the new section to the existing course
+    else {
+      schedule.courses[existingCourseIndex].sections.push(section);
+    }
   }
   // Otherwise, add the new course to the schedule
   else {

--- a/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
@@ -16,7 +16,7 @@ export const scheduleToCSVString = (schedule: di.Schedule): string => {
         durationStr += `${meeting.duration}\n`;
         locationStr += meeting.location.roomNumber
           ? `${meeting.location.building} ${meeting.location.roomNumber}\n`
-          : "meeting.location.building\n";
+          : `${meeting.location.building}\n`;
         roomCapacityStr += `${meeting.location.roomCapacity}\n`;
         daysStr += `${meeting.days.join("")}\n`;
       });
@@ -31,9 +31,9 @@ export const scheduleToCSVString = (schedule: di.Schedule): string => {
         section.letter
       },${section.studentHours ?? course.studentHours},${
         section.facultyHours ?? course.facultyHours
-      },${startTimeStr},${durationStr},${locationStr},${roomCapacityStr},${section.year},${
+      },"${startTimeStr}","${durationStr}","${locationStr}","${roomCapacityStr}",${section.year},${
         section.term
-      },${section.semesterLength},${daysStr},${section.globalMax},${section.localMax},${
+      },${section.semesterLength},"${daysStr}",${section.globalMax},${section.localMax},${
         section.anticipatedSize
       },${section.instructors.join(";")},${section.comments},`;
     });

--- a/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
@@ -5,25 +5,37 @@ export const scheduleToCSVString = (schedule: di.Schedule): string => {
     "name,prefixes,number,section,studentHours,facultyHours,startTime,duration,location,roomCapacity,year,term,semesterLength,days,globalMax,localMax,anticipatedSize,instructors,comments";
   schedule.courses.forEach((course) => {
     course.sections.forEach((section) => {
-      // TODO: Instead of getting the first meeting, iterate through all meetings
-      // TODO: Be wary of commas in strings?
-      let instructorsStr = "";
-      section.instructors.forEach((instructor) => {
-        instructorsStr += `${instructor};`;
+      // Iterate through meetings to construct relevant strings
+      let startTimeStr = "";
+      let durationStr = "";
+      let locationStr = "";
+      let roomCapacityStr = "";
+      let daysStr = "";
+      section.meetings.forEach((meeting) => {
+        startTimeStr += `${meeting.startTime}\n`;
+        durationStr += `${meeting.duration}\n`;
+        locationStr += meeting.location.roomNumber
+          ? `${meeting.location.building} ${meeting.location.roomNumber}\n`
+          : "meeting.location.building\n";
+        roomCapacityStr += `${meeting.location.roomCapacity}\n`;
+        daysStr += `${meeting.days.join("")}\n`;
       });
-      instructorsStr = instructorsStr.slice(0, -1);
-      const meeting = section.meetings ? section.meetings[0] : null;
-      csvStr += `\n${course.name},${course.prefixes.join(";")},${course.number},${section.letter},${
-        section.studentHours ?? course.studentHours
-      },${section.facultyHours ?? course.facultyHours},${meeting ? meeting.startTime : ""},${
-        meeting ? meeting.duration : ""
-      },${meeting ? `${meeting.location.building} ${meeting.location.roomNumber}` : ""},${
-        meeting ? meeting.location.roomCapacity : ""
-      },${section.year},${section.term},${section.semesterLength},${
-        meeting ? meeting.days.join("") : ""
-      },${section.globalMax},${section.localMax},${section.anticipatedSize},${instructorsStr},${
-        section.comments
-      },`;
+      // Remove trailing newlines
+      startTimeStr = startTimeStr.slice(0, -1);
+      durationStr = durationStr.slice(0, -1);
+      locationStr = locationStr.slice(0, -1);
+      roomCapacityStr = roomCapacityStr.slice(0, -1);
+      daysStr = daysStr.slice(0, -1);
+      // TODO: Be wary of commas in strings?
+      csvStr += `\n"${course.name}",${course.prefixes.join(";")},${course.number},${
+        section.letter
+      },${section.studentHours ?? course.studentHours},${
+        section.facultyHours ?? course.facultyHours
+      },${startTimeStr},${durationStr},${locationStr},${roomCapacityStr},${section.year},${
+        section.term
+      },${section.semesterLength},${daysStr},${section.globalMax},${section.localMax},${
+        section.anticipatedSize
+      },${section.instructors.join(";")},${section.comments},`;
     });
   });
   return csvStr;


### PR DESCRIPTION
(Probably should wait to review this until #47 is merged to `develop` because otherwise the changes from that branch will appear in this branch's `Files changed` tab)

To Test:
- `npm install` and `npm start`.
- First try importing and exporting the `math-schedule.csv`, and notice that the exported meetings for classes with multiple meetings are on multiple lines as expected (includes days, startTimes, locations, roomCapacities, durations).
- Also note that the bug with commas in the name of a course is fixed (should only appear in one field), but this could still be a problem with other fields...
- Now try using the add a course/section popup to add a new meeting on an existing section, so for example, try Math 100 A with new days, duration, location, roomCapacity, startTime, and notice that it is added to the same section when exporting.
- Try to break it with edge cases?

Might be useful to log the schedule after parsing/adding courses/sections/meetings for testing purposes.