### PR TITLE
Organize popover menu form

### DIFF
--- a/client-course-schedulizer/src/components/reuseables/AddSectionButton/AddSectionButton.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionButton/AddSectionButton.tsx
@@ -2,11 +2,10 @@ import { Button, ButtonProps, IconButton, Popover } from "@material-ui/core";
 import { Add } from "@material-ui/icons";
 import { AddSectionPopover } from "components";
 import { bindPopover, bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
-import React, { ComponentType } from "react";
+import React from "react";
 import "./AddSectionButton.scss";
 
 interface AddSectionButton extends ButtonProps {
-  // eslint-disable-next-line react/require-default-props
   isIcon?: boolean;
 }
 
@@ -46,7 +45,6 @@ export const AddSectionButton = (props: AddSectionButton) => {
   );
 };
 
-// ref: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36320
-(AddSectionButton as ComponentType<AddSectionButton>).defaultProps = {
+AddSectionButton.defaultProps = {
   isIcon: true,
 };

--- a/client-course-schedulizer/src/components/reuseables/AddSectionButton/AddSectionButton.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionButton/AddSectionButton.tsx
@@ -2,10 +2,11 @@ import { Button, ButtonProps, IconButton, Popover } from "@material-ui/core";
 import { Add } from "@material-ui/icons";
 import { AddSectionPopover } from "components";
 import { bindPopover, bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
-import React from "react";
+import React, { ComponentType } from "react";
 import "./AddSectionButton.scss";
 
 interface AddSectionButton extends ButtonProps {
+  // eslint-disable-next-line react/require-default-props
   isIcon?: boolean;
 }
 
@@ -33,7 +34,7 @@ export const AddSectionButton = (props: AddSectionButton) => {
           horizontal: "left",
           vertical: "bottom",
         }}
-        PaperProps={{ style: { maxWidth: "50%", minWidth: "500px" } }}
+        PaperProps={{ style: { minWidth: "500px" } }}
         transformOrigin={{
           horizontal: "right",
           vertical: "top",
@@ -45,6 +46,7 @@ export const AddSectionButton = (props: AddSectionButton) => {
   );
 };
 
-AddSectionButton.defaultProps = {
+// ref: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36320
+(AddSectionButton as ComponentType<AddSectionButton>).defaultProps = {
   isIcon: true,
 };

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.scss
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.scss
@@ -2,6 +2,6 @@
   padding: 0.7em;
 }
 
-.title {
-  text-align: center;
+.popover-title {
+  font-weight: 600 !important;
 }

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { Box, Button, Grid, Typography } from "@material-ui/core";
+import { Box, Button, Grid, InputAdornment, Typography } from "@material-ui/core";
 import { GridItemCheckboxGroup, GridItemRadioGroup, GridItemTextField } from "components";
 import React, { ChangeEvent, useContext, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -44,6 +44,10 @@ export const AddSectionPopover = () => {
     setSemesterLength(e.target.value as SemesterLengthOption);
   };
 
+  const isHalfSemester = semesterLength === SemesterLengthOption.HalfSemester;
+  const isIntensiveSemester = semesterLength === SemesterLengthOption.IntensiveSemester;
+  const isCustomSemester = semesterLength === SemesterLengthOption.CustomSemester;
+
   return (
     <form className="popover-container">
       <Box mb={SPACING}>
@@ -87,7 +91,15 @@ export const AddSectionPopover = () => {
             type: "time",
           }}
         />
-        <GridItemTextField label="Duration" register={register} />
+        <GridItemTextField
+          label="Duration"
+          register={register}
+          textFieldProps={{
+            InputProps: {
+              endAdornment: <InputAdornment position="end">min</InputAdornment>,
+            },
+          }}
+        />
       </Grid>
       <Grid container spacing={SPACING}>
         <GridItemCheckboxGroup
@@ -113,7 +125,7 @@ export const AddSectionPopover = () => {
           register={register}
         />
         <Grid item xs>
-          {semesterLength === SemesterLengthOption.HalfSemester && (
+          {isHalfSemester && (
             <GridItemRadioGroup
               control={control}
               defaultValue={SemesterLength.HalfFirst}
@@ -124,7 +136,7 @@ export const AddSectionPopover = () => {
               register={register}
             />
           )}
-          {semesterLength === SemesterLengthOption.IntensiveSemester && (
+          {isIntensiveSemester && (
             <GridItemRadioGroup
               control={control}
               defaultValue={SemesterLength.IntensiveA}
@@ -135,7 +147,7 @@ export const AddSectionPopover = () => {
               register={register}
             />
           )}
-          {semesterLength === SemesterLengthOption.CustomSemester && (
+          {isCustomSemester && (
             <Grid container direction="column" spacing={SPACING}>
               {/* TODO: add support for custom */}
               <GridItemTextField
@@ -172,8 +184,8 @@ export const AddSectionPopover = () => {
       <Grid alignItems="flex-end" container justify="space-between">
         <Grid item>
           <Typography variant="caption">
-            Use <b>tab</b> and <b>shift + tab</b> to navigate, <b>space bar</b> to select Days, and{" "}
-            <b>return</b> to submit.
+            Tip: use <b>tab</b> and <b>shift + tab</b> to navigate, <b>space bar</b> to select days,{" "}
+            <b>arrow keys</b> to select term and others, and <b>return</b> to submit.
           </Typography>
         </Grid>
         <Grid item>

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { Button, Grid, Typography } from "@material-ui/core";
+import { Box, Button, Grid, Typography } from "@material-ui/core";
 import { GridItemCheckboxGroup, GridItemRadioGroup, GridItemTextField } from "components";
 import React, { ChangeEvent, useContext, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -16,7 +16,7 @@ import {
 import "./AddSectionPopover.scss";
 import { schema, SectionInput, updateScheduleWithNewSection } from "./AddSectionPopoverService";
 
-const SPACING = 4;
+const SPACING = 2;
 
 /* A form to input information to add a schedule */
 export const AddSectionPopover = () => {
@@ -29,7 +29,9 @@ export const AddSectionPopover = () => {
   const { register, handleSubmit, control } = useForm<SectionInput>({
     resolver: yupResolver(schema),
   });
-  const [semesterLength, setSemesterLength] = useState("full");
+  const [semesterLength, setSemesterLength] = useState<SemesterLengthOption>(
+    SemesterLengthOption.FullSemester,
+  );
 
   // handlers
   const onSubmit = (data: SectionInput) => {
@@ -38,66 +40,54 @@ export const AddSectionPopover = () => {
     appDispatch({ payload: { schedule }, type: "setScheduleData" });
     setIsCSVLoading(false);
   };
-
   const onSemesterLengthChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setSemesterLength(e.target.value);
+    setSemesterLength(e.target.value as SemesterLengthOption);
   };
 
   return (
     <form className="popover-container">
-      <Typography className="title" variant="h4">
-        Add/Update Section
-      </Typography>
+      <Box mb={SPACING}>
+        <Typography className="popover-title" variant="h4">
+          Add Section
+        </Typography>
+      </Box>
       <Grid container spacing={SPACING}>
         {/* TODO: Dropdown for courses already in system */}
-        <GridItemTextField label="Prefix" register={register} />
+        <GridItemTextField
+          label="Prefix"
+          register={register}
+          textFieldProps={{ autoFocus: true }}
+        />
         <GridItemTextField label="Number" register={register} />
         <GridItemTextField label="Section" register={register} />
-        <GridItemTextField label="Name" register={register} />
+        <GridItemTextField label="Class Name" register={register} />
+        <Grid item xs>
+          <span>{/* TODO: add error messages? */}</span>
+        </Grid>
       </Grid>
       <Grid container spacing={SPACING}>
         {/* TODO: Dropdown for instructors with option to add new one */}
         <GridItemTextField label="Instructor" register={register} />
+        <GridItemTextField label="Student Hours" register={register} />
+        <GridItemTextField label="Faculty Hours" register={register} />
         {/* TODO: Dropdown for rooms with option to add new one */}
         <GridItemTextField label="Location" register={register} />
-        <GridItemTextField
-          label="Room Capacity"
-          register={register}
-          textFieldProps={{ name: "roomCapacity" }}
-        />
-        <GridItemTextField
-          label="Faculty Hours"
-          register={register}
-          textFieldProps={{ name: "facultyHours" }}
-        />
-        <GridItemTextField
-          label="Student Hours"
-          register={register}
-          textFieldProps={{ name: "studentHours" }}
-        />
+        <GridItemTextField label="Room Capacity" register={register} />
       </Grid>
       <Grid container spacing={SPACING}>
-        <GridItemTextField
-          label="Anticipated Size"
-          register={register}
-          textFieldProps={{ name: "anticipatedSize" }}
-        />
-        <GridItemTextField
-          label="Global Max"
-          register={register}
-          textFieldProps={{ name: "globalMax" }}
-        />
-        <GridItemTextField
-          label="Local Max"
-          register={register}
-          textFieldProps={{ name: "localMax" }}
-        />
-        <GridItemTextField label="Duration" register={register} />
+        <GridItemTextField label="Anticipated Size" register={register} />
+        <GridItemTextField label="Global Max" register={register} />
+        <GridItemTextField label="Local Max" register={register} />
         <GridItemTextField
           label="Start Time"
           register={register}
-          textFieldProps={{ defaultValue: "08:00", name: "startTime", type: "time" }}
+          textFieldProps={{
+            defaultValue: "08:00",
+            fullWidth: true,
+            type: "time",
+          }}
         />
+        <GridItemTextField label="Duration" register={register} />
       </Grid>
       <Grid container spacing={SPACING}>
         <GridItemCheckboxGroup
@@ -109,54 +99,78 @@ export const AddSectionPopover = () => {
         />
         <GridItemRadioGroup
           control={control}
-          defaultValue="FA"
+          defaultValue={Term.Fall}
           label="Term"
           options={Object.values(Term)}
           register={register}
         />
         <GridItemRadioGroup
           control={control}
-          defaultValue="full"
+          defaultValue={SemesterLengthOption.FullSemester}
           label="Semester Length"
-          lowercase
-          name="semesterLength"
           onChange={onSemesterLengthChange}
           options={Object.values(SemesterLengthOption)}
           register={register}
         />
-        {semesterLength === "half" && (
-          <GridItemRadioGroup
-            control={control}
-            defaultValue="First"
-            label="Half Semester"
-            lowercase
-            name="half"
-            options={Object.values(SemesterLength).filter((h) => {
-              return Object.values(Half).includes(h);
-            })}
-            register={register}
-          />
-        )}
-        {semesterLength === "intensive" && (
-          <GridItemRadioGroup
-            control={control}
-            defaultValue="A"
-            label="Intensive Semester"
-            name="intensive"
-            options={Object.values(SemesterLength).filter((i) => {
-              return Object.values(Intensive).includes(i);
-            })}
-            register={register}
-          />
-        )}
+        <Grid item xs>
+          {semesterLength === SemesterLengthOption.HalfSemester && (
+            <GridItemRadioGroup
+              control={control}
+              defaultValue={SemesterLength.HalfFirst}
+              label="Half Semester"
+              options={Object.values(SemesterLength).filter((h) => {
+                return Object.values(Half).includes(h);
+              })}
+              register={register}
+            />
+          )}
+          {semesterLength === SemesterLengthOption.IntensiveSemester && (
+            <GridItemRadioGroup
+              control={control}
+              defaultValue={SemesterLength.IntensiveA}
+              label="Intensive Semester"
+              options={Object.values(SemesterLength).filter((i) => {
+                return Object.values(Intensive).includes(i);
+              })}
+              register={register}
+            />
+          )}
+          {semesterLength === SemesterLengthOption.CustomSemester && (
+            <Grid container direction="column" spacing={SPACING}>
+              {/* TODO: add support for custom */}
+              <GridItemTextField
+                label="Start Date"
+                register={register}
+                textFieldProps={{
+                  defaultValue: "2020-20-20",
+                  disabled: true,
+                  fullWidth: true,
+                  // type: "date",
+                }}
+              />
+              <GridItemTextField
+                label="End Date"
+                register={register}
+                textFieldProps={{
+                  defaultValue: "2020-20-20",
+                  disabled: true,
+                  // type: "date",
+                }}
+              />
+              <Typography variant="caption">
+                Custom semester lengths are not support yet.
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
         <GridItemTextField
           label="Notes"
           register={register}
           textFieldProps={{ multiline: true, name: "comments", rows: 4 }}
         />
       </Grid>
-      <Grid container>
-        <Grid item xs>
+      <Grid container justify="flex-end">
+        <Grid item>
           <Button color="primary" onClick={handleSubmit(onSubmit)} variant="contained">
             Submit
           </Button>

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
@@ -169,7 +169,13 @@ export const AddSectionPopover = () => {
           textFieldProps={{ multiline: true, name: "comments", rows: 4 }}
         />
       </Grid>
-      <Grid container justify="flex-end">
+      <Grid alignItems="flex-end" container justify="space-between">
+        <Grid item>
+          <Typography variant="caption">
+            Use <b>tab</b> and <b>shift + tab</b> to navigate, <b>space bar</b> to select Days, and{" "}
+            <b>return</b> to submit.
+          </Typography>
+        </Grid>
         <Grid item>
           <Button color="primary" onClick={handleSubmit(onSubmit)} variant="contained">
             Submit

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
@@ -15,13 +15,16 @@ import {
   Course,
   Day,
   Half,
+  Instructor,
   Intensive,
   Location,
   Meeting,
+  Prefix,
   Section,
   SemesterLength,
   SemesterLengthOption,
   Term,
+  Weekday,
 } from "utilities/interfaces";
 import { array, object } from "yup";
 import "./AddSectionPopover.scss";
@@ -34,27 +37,19 @@ interface SectionInput {
   facultyHours: Section["facultyHours"];
   globalMax: Section["globalMax"];
   half: Half;
-  instructor: string;
+  instructor: Instructor;
   intensive?: Intensive;
   localMax: Section["localMax"];
   location: string;
   name: Course["name"];
   number: Course["number"];
-  prefix: string;
+  prefix: Prefix;
   roomCapacity: Location["roomCapacity"];
   section: Section["letter"];
   semesterLength: SemesterLengthOption;
   startTime: Meeting["startTime"];
   studentHours: Section["studentHours"];
   term: Section["term"];
-}
-
-enum Weekday {
-  Monday = Day.Monday,
-  Tuesday = Day.Tuesday,
-  Wednesday = Day.Wednesday,
-  Thursday = Day.Thursday,
-  Friday = Day.Friday,
 }
 
 const convertToSemesterLength = (sl: Half | Intensive | SemesterLengthOption): SemesterLength => {
@@ -76,24 +71,23 @@ const convertToSemesterLength = (sl: Half | Intensive | SemesterLengthOption): S
   }
 };
 
+const SPACING = 4;
+
+// Remove false values from days array
+const schema = object().shape({
+  days: array().transform((d) => {
+    return d.filter((day: boolean | string) => {
+      return day;
+    });
+  }),
+});
+
 export const AddSectionPopover = () => {
   const {
     appState: { schedule },
     appDispatch,
     setIsCSVLoading,
   } = useContext(AppContext);
-
-  const spacing = 4;
-
-  // Remove false values from days array
-  const schema = object().shape({
-    days: array().transform((d) => {
-      return d.filter((day: boolean | string) => {
-        return day;
-      });
-    }),
-  });
-
   const { register, handleSubmit, control } = useForm<SectionInput>({
     resolver: yupResolver(schema),
   });
@@ -156,14 +150,14 @@ export const AddSectionPopover = () => {
       <Typography className="title" variant="h4">
         Add/Update Section
       </Typography>
-      <Grid container spacing={spacing}>
+      <Grid container spacing={SPACING}>
         {/* TODO: Dropdown for courses already in system */}
         <GridItemTextField label="Prefix" register={register} />
         <GridItemTextField label="Number" register={register} />
         <GridItemTextField label="Section" register={register} />
         <GridItemTextField label="Name" register={register} />
       </Grid>
-      <Grid container spacing={spacing}>
+      <Grid container spacing={SPACING}>
         {/* TODO: Dropdown for instructors with option to add new one */}
         <GridItemTextField label="Instructor" register={register} />
         {/* TODO: Dropdown for rooms with option to add new one */}
@@ -184,7 +178,7 @@ export const AddSectionPopover = () => {
           textFieldProps={{ name: "studentHours" }}
         />
       </Grid>
-      <Grid container spacing={spacing}>
+      <Grid container spacing={SPACING}>
         <GridItemTextField
           label="Anticipated Size"
           register={register}
@@ -207,7 +201,7 @@ export const AddSectionPopover = () => {
           textFieldProps={{ defaultValue: "08:00", name: "startTime", type: "time" }}
         />
       </Grid>
-      <Grid container spacing={spacing}>
+      <Grid container spacing={SPACING}>
         <GridItemCheckboxGroup
           label="Days"
           options={Object.values(Day).filter((day) => {

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopoverService.ts
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopoverService.ts
@@ -1,0 +1,130 @@
+import {
+  insertSectionCourse,
+  instructorCase,
+  locationCase,
+  prefixCase,
+  startTimeCase,
+} from "utilities";
+import {
+  Course,
+  Half,
+  Instructor,
+  Intensive,
+  Location,
+  Meeting,
+  Prefix,
+  Schedule,
+  Section,
+  SemesterLength,
+  SemesterLengthOption,
+} from "utilities/interfaces";
+import { array, object } from "yup";
+
+// Defines interface for the section popover input
+export interface SectionInput {
+  anticipatedSize: Section["anticipatedSize"];
+  comments: Section["comments"];
+  days: Meeting["days"];
+  duration: Meeting["duration"];
+  facultyHours: Section["facultyHours"];
+  globalMax: Section["globalMax"];
+  half: Half;
+  instructor: Instructor;
+  intensive?: Intensive;
+  localMax: Section["localMax"];
+  location: string;
+  name: Course["name"];
+  number: Course["number"];
+  prefix: Prefix;
+  roomCapacity: Location["roomCapacity"];
+  section: Section["letter"];
+  semesterLength: SemesterLengthOption;
+  startTime: Meeting["startTime"];
+  studentHours: Section["studentHours"];
+  term: Section["term"];
+}
+
+// A helpful function to convert the semester length from the input
+export const convertToSemesterLength = (
+  sl: Half | Intensive | SemesterLengthOption,
+): SemesterLength => {
+  switch (sl) {
+    case Half.First:
+      return SemesterLength.HalfFirst;
+    case Half.Second:
+      return SemesterLength.HalfSecond;
+    case Intensive.A:
+      return SemesterLength.IntensiveA;
+    case Intensive.B:
+      return SemesterLength.IntensiveB;
+    case Intensive.C:
+      return SemesterLength.IntensiveC;
+    case Intensive.D:
+      return SemesterLength.IntensiveD;
+    default:
+      return SemesterLength.Full;
+  }
+};
+
+// Remove false values from days array. Used by useForm()
+export const schema = object().shape({
+  days: array().transform((d) => {
+    return d.filter((day: boolean | string) => {
+      return day;
+    });
+  }),
+});
+
+/* Used to map the input from the popover form to the
+ internal JSON object type.  */
+export const mapInputToInternalTypes = (data: SectionInput) => {
+  const location = locationCase(data.location);
+  const semesterType = convertToSemesterLength(data.intensive || data.half || data.semesterLength);
+  const newSection: Section = {
+    anticipatedSize: Number(data.anticipatedSize),
+    comments: data.comments,
+    facultyHours: Number(data.facultyHours),
+    globalMax: Number(data.globalMax),
+    instructors: instructorCase(data.instructor),
+    letter: data.section,
+    localMax: Number(data.localMax),
+    meetings: [
+      {
+        days: data.days,
+        duration: Number(data.duration),
+        location: {
+          building: location[0],
+          roomCapacity: Number(data.roomCapacity),
+          roomNumber: location[1],
+        },
+        startTime: startTimeCase(data.startTime),
+      },
+    ],
+    semesterLength: semesterType,
+    studentHours: Number(data.studentHours),
+    term: data.term,
+    year: "2021-2022",
+  };
+
+  const newCourse: Course = {
+    facultyHours: Number(data.facultyHours),
+    name: data.name,
+    number: data.number,
+    prefixes: prefixCase(data.prefix),
+    // The newSection will be added later in insertSectionCourse()
+    sections: [],
+    studentHours: Number(data.studentHours),
+  };
+  return { newCourse, newSection };
+};
+
+// Update the schedule via pass by sharing.
+export const updateScheduleWithNewSection = (data: SectionInput, schedule: Schedule) => {
+  const {
+    newSection,
+    newCourse,
+  }: { newCourse: Course; newSection: Section } = mapInputToInternalTypes(data);
+
+  // Insert the Section to the Schedule, either as a new Course or to an existing Course
+  insertSectionCourse(schedule, newSection, newCourse);
+};

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/index.ts
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/index.ts
@@ -1,1 +1,2 @@
 export * from "./AddSectionPopover";
+export * from "./AddSectionPopoverService";

--- a/client-course-schedulizer/src/components/reuseables/GridItem/GridItemCheckboxGroup/GridItemCheckboxGroup.tsx
+++ b/client-course-schedulizer/src/components/reuseables/GridItem/GridItemCheckboxGroup/GridItemCheckboxGroup.tsx
@@ -1,39 +1,37 @@
 import { Checkbox, FormControlLabel, FormLabel, Grid } from "@material-ui/core";
+import { camelCase } from "lodash";
 import React from "react";
 import { useForm } from "react-hook-form";
 import "./GridItemCheckboxGroup.scss";
 
-export const GridItemCheckboxGroup = ({
-  label,
-  name,
-  options,
-  register,
-}: {
+interface GridItemCheckboxGroup {
   label: string;
-  name?: string;
   options: string[];
   register: ReturnType<typeof useForm>["register"];
-}) => {
+}
+
+export const GridItemCheckboxGroup = ({ label, options, register }: GridItemCheckboxGroup) => {
   return (
     <Grid item xs>
       <FormLabel component="legend">{label}</FormLabel>
-      {options.map((o, i) => {
-        return (
-          <FormControlLabel
-            key={o.toLowerCase()}
-            control={<Checkbox />}
-            defaultChecked={false}
-            inputRef={register}
-            label={o}
-            name={`${name || label.toLowerCase()}[${i}]`}
-            value={o}
-          />
-        );
-      })}
+      <Grid container direction="column">
+        {options.map((o, i) => {
+          return (
+            <Grid key={o.toLowerCase()} item>
+              <FormControlLabel
+                control={<Checkbox />}
+                defaultChecked={false}
+                inputRef={register}
+                label={o}
+                name={`${camelCase(label)}[${i}]`}
+                value={o}
+              />
+            </Grid>
+          );
+        })}
+      </Grid>
     </Grid>
   );
 };
 
-GridItemCheckboxGroup.defaultProps = {
-  name: undefined,
-};
+GridItemCheckboxGroup.defaultProps = {};

--- a/client-course-schedulizer/src/components/reuseables/GridItem/GridItemRadioGroup/GridItemRadioGroup.tsx
+++ b/client-course-schedulizer/src/components/reuseables/GridItem/GridItemRadioGroup/GridItemRadioGroup.tsx
@@ -1,27 +1,30 @@
 import { FormControlLabel, FormLabel, Grid, Radio, RadioGroup } from "@material-ui/core";
+import { camelCase } from "lodash";
 import React, { ChangeEvent } from "react";
 import { Controller, useForm } from "react-hook-form";
 import "./GridItemRadioGroup.scss";
 
-export const GridItemRadioGroup = ({
-  control,
-  defaultValue,
-  label,
-  lowercase,
-  name,
-  onChange,
-  options,
-  register,
-}: {
+export interface GridItemRadioGroup {
   control: ReturnType<typeof useForm>["control"];
   defaultValue: string;
+  disabled?: boolean;
   label: string;
   lowercase?: boolean;
-  name?: string;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   options: string[];
   register: ReturnType<typeof useForm>["register"];
-}) => {
+}
+
+export const GridItemRadioGroup = ({
+  control,
+  defaultValue,
+  disabled,
+  label,
+  lowercase,
+  onChange,
+  options,
+  register,
+}: GridItemRadioGroup) => {
   return (
     <Grid item xs>
       <FormLabel component="legend">{label}</FormLabel>
@@ -30,13 +33,14 @@ export const GridItemRadioGroup = ({
         as={RadioGroup}
         control={control}
         defaultValue={defaultValue}
-        name={name || label.toLowerCase()}
+        name={camelCase(label)}
       >
         {options.map((o) => {
           return (
             <FormControlLabel
               key={o.toLowerCase()}
               control={<Radio onChange={onChange} />}
+              disabled={disabled}
               label={o}
               value={lowercase ? o.toLowerCase() : o}
             />
@@ -48,7 +52,7 @@ export const GridItemRadioGroup = ({
 };
 
 GridItemRadioGroup.defaultProps = {
+  disabled: false,
   lowercase: false,
-  name: undefined,
   onChange: undefined,
 };

--- a/client-course-schedulizer/src/components/reuseables/GridItem/GridItemTextField/GridItemTextField.tsx
+++ b/client-course-schedulizer/src/components/reuseables/GridItem/GridItemTextField/GridItemTextField.tsx
@@ -1,20 +1,25 @@
 import { Grid, StandardTextFieldProps, TextField } from "@material-ui/core";
+import { camelCase } from "lodash";
 import React from "react";
 import { useForm } from "react-hook-form";
 import "./GridItemTextField.scss";
 
-export const GridItemTextField = ({
-  label,
-  register,
-  textFieldProps,
-}: {
+interface GridItemTextField {
   label: string;
   register: ReturnType<typeof useForm>["register"];
   textFieldProps?: StandardTextFieldProps;
-}) => {
+}
+
+export const GridItemTextField = ({ label, register, textFieldProps }: GridItemTextField) => {
   return (
     <Grid item xs>
-      <TextField inputRef={register} label={label} name={label.toLowerCase()} {...textFieldProps} />
+      <TextField
+        inputRef={register}
+        label={label}
+        name={camelCase(label)}
+        {...textFieldProps}
+        variant="outlined"
+      />
     </Grid>
   );
 };

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces.ts
@@ -26,6 +26,14 @@ export enum Day {
   Sunday = "Su",
 }
 
+export enum Weekday {
+  Monday = Day.Monday,
+  Tuesday = Day.Tuesday,
+  Wednesday = Day.Wednesday,
+  Thursday = Day.Thursday,
+  Friday = Day.Friday,
+}
+
 export enum Half {
   First = SemesterLength.HalfFirst,
   Second = SemesterLength.HalfSecond,
@@ -60,14 +68,18 @@ export interface Meeting {
   startTime: string;
 }
 
+export type Prefix = string;
+
 export interface Course {
   facultyHours: number;
   name: string;
   number: string;
-  prefixes: string[];
+  prefixes: Prefix[];
   sections: Section[];
   studentHours: number;
 }
+
+export type Instructor = string;
 
 export interface Section {
   anticipatedSize: number;
@@ -75,7 +87,7 @@ export interface Section {
   // Overrides Course value
   facultyHours?: number;
   globalMax: number;
-  instructors: string[];
+  instructors: Instructor[];
   letter: string;
   localMax: number;
   // Multiple Meetings possible if time/room differs on different days

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/dayInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/dayInterfaces.ts
@@ -1,0 +1,19 @@
+/* eslint-disable typescript-sort-keys/string-enum */
+
+export enum Day {
+  Monday = "M",
+  Tuesday = "T",
+  Wednesday = "W",
+  Thursday = "Th",
+  Friday = "F",
+  Saturday = "S",
+  Sunday = "Su",
+}
+
+export enum Weekday {
+  Monday = Day.Monday,
+  Tuesday = Day.Tuesday,
+  Wednesday = Day.Wednesday,
+  Thursday = Day.Thursday,
+  Friday = Day.Friday,
+}

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/index.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/index.ts
@@ -1,0 +1,3 @@
+export * from "./dayInterfaces";
+export * from "./scheduleInterfaces";
+export * from "./termInterfaces";

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/scheduleInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/scheduleInterfaces.ts
@@ -1,56 +1,5 @@
 /* eslint-disable typescript-sort-keys/string-enum */
-export enum Term {
-  Fall = "FA",
-  Interim = "IN", // TODO: Remove?
-  Spring = "SP",
-  Summer = "SU", // TODO: Is this a thing?
-}
-
-export enum SemesterLength {
-  Full = "Full",
-  HalfFirst = "First",
-  HalfSecond = "Second",
-  IntensiveA = "A",
-  IntensiveB = "B",
-  IntensiveC = "C",
-  IntensiveD = "D",
-}
-
-export enum Day {
-  Monday = "M",
-  Tuesday = "T",
-  Wednesday = "W",
-  Thursday = "Th",
-  Friday = "F",
-  Saturday = "S",
-  Sunday = "Su",
-}
-
-export enum Weekday {
-  Monday = Day.Monday,
-  Tuesday = Day.Tuesday,
-  Wednesday = Day.Wednesday,
-  Thursday = Day.Thursday,
-  Friday = Day.Friday,
-}
-
-export enum Half {
-  First = SemesterLength.HalfFirst,
-  Second = SemesterLength.HalfSecond,
-}
-
-export enum Intensive {
-  A = SemesterLength.IntensiveA,
-  B = SemesterLength.IntensiveB,
-  C = SemesterLength.IntensiveC,
-  D = SemesterLength.IntensiveD,
-}
-
-export enum SemesterLengthOption {
-  FullSemester = "Full",
-  HalfSemester = "Half",
-  IntensiveSemester = "Intensive",
-}
+import { Day, SemesterLength, Term } from ".";
 
 export interface Location {
   building: string;

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/termInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/termInterfaces.ts
@@ -1,0 +1,35 @@
+/* eslint-disable typescript-sort-keys/string-enum */
+export enum Term {
+  Fall = "FA",
+  Interim = "IN", // TODO: Remove?
+  Spring = "SP",
+  Summer = "SU", // TODO: Is this a thing?
+}
+
+export enum SemesterLength {
+  Full = "Full",
+  HalfFirst = "First",
+  HalfSecond = "Second",
+  IntensiveA = "A",
+  IntensiveB = "B",
+  IntensiveC = "C",
+  IntensiveD = "D",
+}
+
+export enum Half {
+  First = SemesterLength.HalfFirst,
+  Second = SemesterLength.HalfSecond,
+}
+
+export enum Intensive {
+  A = SemesterLength.IntensiveA,
+  B = SemesterLength.IntensiveB,
+  C = SemesterLength.IntensiveC,
+  D = SemesterLength.IntensiveD,
+}
+
+export enum SemesterLengthOption {
+  FullSemester = "Full",
+  HalfSemester = "Half",
+  IntensiveSemester = "Intensive",
+}

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/termInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/termInterfaces.ts
@@ -32,4 +32,5 @@ export enum SemesterLengthOption {
   FullSemester = "Full",
   HalfSemester = "Half",
   IntensiveSemester = "Intensive",
+  CustomSemester = "Custom",
 }


### PR DESCRIPTION
This is the first of a three-part PR involving the popover menu. In part one, the goal was the split up the logic and the structure of the popover component. Also, the goal of this was the remove potential mismatches of related data. For example, the component name depends on the component label, so this PR allows one to derive the name from the label. 

Let me know what you think! I tried to split up the code in a way I thought was logical, but if you disagree, let me know and we can find a better solution! 

Part 2 will be validating the form.
Part 3 will be testing the form.

Also, I didn't realize that Jon is editing the Popover so I apologize for the merge conflicts we will encounter at some point. 

closes #56 