### PR TITLE
Fix calendar label bugs

### DIFF
--- a/client-course-schedulizer/src/utilities/services/scheduleService.ts
+++ b/client-course-schedulizer/src/utilities/services/scheduleService.ts
@@ -76,8 +76,11 @@ export const getMinAndMaxTimes = (schedule: Schedule) => {
   const endTimes = map(meetings, (meeting) => {
     return moment(meeting.startTime, "h:mma").add(meeting.duration, "minutes");
   });
-  const minTime = minBy(startTimes)?.format("HH:mm") || "6:00";
-  const maxTime = maxBy(endTimes)?.format("HH:mm") || "22:00";
+  const minTime = (minBy(startTimes) || moment("06:00", "HH:mm")).startOf("hour").format("HH:mm");
+  const maxTime = (maxBy(endTimes) || moment("22:00", "HH:mm"))
+    .add(1, "hours")
+    .startOf("hour")
+    .format("HH:mm");
   return {
     maxTime,
     minTime,


### PR DESCRIPTION
When adding a class from scratch:
- Making the only class in the schedule have a duration of 30 minutes or below should no longer cause a crash
- The hour labels on the left of the schedule should be placed properly (especially when the course starts not on an hour)

Try to break this with strange course start times and durations. For testing, it is probably best to start fresh and add courses manually, and refresh the page to start fresh again every once and a while.

Closes #61 
Closes #63 