### PR TITLE
Fix Import Button Hitbox

### DIFF
--- a/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/CSVActions.scss
+++ b/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/CSVActions.scss
@@ -1,1 +1,3 @@
-
+.hidden {
+  display: none !important;
+}

--- a/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/CSVActions.tsx
+++ b/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/CSVActions.tsx
@@ -28,9 +28,11 @@ export const CSVActions = () => {
         }}
         {...bindMenu(popupState)}
       >
-        <MenuItem button className="MuiButton-textPrimary">
-          <ImportInputWrapper>IMPORT CSV</ImportInputWrapper>
-        </MenuItem>
+        <ImportInputWrapper>
+          <MenuItem button className="MuiButton-textPrimary">
+            IMPORT CSV
+          </MenuItem>
+        </ImportInputWrapper>
         <MenuItem button className="MuiButton-textSecondary" onClick={onExportClick}>
           EXPORT CSV
         </MenuItem>

--- a/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/ImportButton/ImportButton.scss
+++ b/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/ImportButton/ImportButton.scss
@@ -1,3 +1,0 @@
-.hidden {
-  display: none !important;
-}

--- a/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/ImportButton/ImportButton.tsx
+++ b/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/ImportButton/ImportButton.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from "@material-ui/core";
 import { ImportInputWrapper } from "components";
 import React from "react";
-import "./ImportButton.scss";
+import "../CSVActions.scss";
 
 /* An import button that is stylable using the Mat UI props. */
 export const ImportButton = (btnProps: ButtonProps) => {


### PR DESCRIPTION
To Test:
- Make sure that the import button when initially loading the page can be clicked anywhere:

![image](https://user-images.githubusercontent.com/51130302/107601077-9e2e6e00-6bf3-11eb-882e-8f1c9e09b7e3.png)

- Make sure that the other import button can also be clicked anywhere (especially on the bottom, top, and sides):

![image](https://user-images.githubusercontent.com/51130302/107601153-d46bed80-6bf3-11eb-9406-fc04fbd44ca9.png)

Closes #76