### PR TITLE
additive import button

### DIFF
--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -4679,6 +4679,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6476,18 +6477,18 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "dependencies": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
@@ -10748,6 +10749,7 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -16457,6 +16459,7 @@
         "eslint-plugin-react-hooks": "^1.6.1",
         "file-loader": "4.3.0",
         "fs-extra": "^8.1.0",
+        "fsevents": "2.1.2",
         "html-webpack-plugin": "4.0.0-beta.11",
         "identity-obj-proxy": "3.0.0",
         "jest": "24.9.0",
@@ -20230,7 +20233,8 @@
       "dependencies": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
       },
       "optionalDependencies": {
         "watchpack-chokidar2": "^2.0.0"
@@ -20527,6 +20531,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -27114,18 +27119,18 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {

--- a/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/CSVActions.tsx
+++ b/client-course-schedulizer/src/components/Tabs/tabComponents/CSVActions/CSVActions.tsx
@@ -29,15 +29,16 @@ export const CSVActions = () => {
         }}
         {...bindMenu(popupState)}
       >
-        <ImportInputWrapper>
-          <MenuItem button className="MuiButton-textPrimary">
-            IMPORT SCHEDULE
-          </MenuItem>
+        <ImportInputWrapper isAdditiveImport={false}>
+          <MenuItem button>IMPORT NEW SCHEDULE</MenuItem>
         </ImportInputWrapper>
-        <MenuItem button className="MuiButton-textSecondary" onClick={onExportClick}>
+        <ImportInputWrapper isAdditiveImport>
+          <MenuItem button>ADD SCHEDULE</MenuItem>
+        </ImportInputWrapper>
+        <MenuItem button onClick={onExportClick}>
           EXPORT FINAL CSV
         </MenuItem>
-        <MenuItem button className="MuiButton-textSecondary" onClick={onFullExportClick}>
+        <MenuItem button onClick={onFullExportClick}>
           EXPORT DRAFT CSV
         </MenuItem>
       </Menu>

--- a/client-course-schedulizer/src/components/reuseables/ImportInputWrapper/ImportInputWrapper.tsx
+++ b/client-course-schedulizer/src/components/reuseables/ImportInputWrapper/ImportInputWrapper.tsx
@@ -1,21 +1,33 @@
 import React, { PropsWithChildren } from "react";
 import { useImportFile } from "utilities";
 
-/* Wraps whatever children in a label that will capture the click
-on the children and open the file explorer to upload a file.
-*/
-export const ImportInputWrapper = ({ children }: PropsWithChildren<{}>) => {
-  const onInputChange = useImportFile();
+interface ImportInputWrapperProps {
+  /**
+   * If true, will add schedules together.
+   *   false will override the current schedule.
+   *
+   * @type {boolean}
+   * @memberof ImportInputWrapperProps
+   * @optional
+   */
+  isAdditiveImport?: boolean;
+}
+
+/**
+ * Wraps whatever children in a label that will capture the click
+ *   on the children and open the file explorer to upload a file.
+ */
+export const ImportInputWrapper = ({
+  children,
+  isAdditiveImport = false,
+}: PropsWithChildren<ImportInputWrapperProps>) => {
+  const onInputChange = useImportFile(isAdditiveImport);
+
+  const id = `${isAdditiveImport ? "additive-" : ""}import-button`;
 
   return (
-    <label htmlFor="import-button">
-      <input
-        accept=".csv, .xlsx"
-        className="hidden"
-        id="import-button"
-        onChange={onInputChange}
-        type="file"
-      />
+    <label htmlFor={id}>
+      <input accept=".csv, .xlsx" className="hidden" id={id} onChange={onInputChange} type="file" />
       {children}
     </label>
   );

--- a/client-course-schedulizer/src/utilities/contexts/appContext.ts
+++ b/client-course-schedulizer/src/utilities/contexts/appContext.ts
@@ -18,3 +18,4 @@ export const AppContext = createContext<AppContext>({
   isCSVLoading: false,
   setIsCSVLoading: voidFn,
 });
+AppContext.displayName = "AppContext";

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from "lodash";
+import { cloneDeep, isEqual } from "lodash";
 import papa from "papaparse";
 import { Course, emptyCourse, emptySection, Meeting, Schedule, Section } from "utilities";
 import { getCourse, getSection } from "utilities/services";
@@ -159,12 +159,27 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
       const existingSectionIndex = schedule.courses[existingCourseIndex].sections.indexOf(
         existingSection,
       );
-      // TODO: Avoid duplicate meetings?
-      schedule.courses[existingCourseIndex].sections[
-        existingSectionIndex
-      ].meetings = schedule.courses[existingCourseIndex].sections[
-        existingSectionIndex
-      ].meetings.concat(section.meetings);
+      const newMeetings = section.meetings;
+
+      // Only add meetings which don't already exist
+      newMeetings.forEach((newMeeting) => {
+        let meetingExists = false;
+        schedule.courses[existingCourseIndex].sections[existingSectionIndex].meetings.forEach(
+          (oldMeeting) => {
+            // Short-circuit if duplicate is found
+            if (!meetingExists && isEqual(newMeeting, oldMeeting)) {
+              meetingExists = true;
+            }
+          },
+        );
+        if (!meetingExists) {
+          schedule.courses[existingCourseIndex].sections[
+            existingSectionIndex
+          ].meetings = schedule.courses[existingCourseIndex].sections[
+            existingSectionIndex
+          ].meetings.concat(newMeeting);
+        }
+      });
     }
     // Otherwise, add the new section to the existing course
     else {

--- a/client-course-schedulizer/src/utilities/hooks/importRemoteFileHook.ts
+++ b/client-course-schedulizer/src/utilities/hooks/importRemoteFileHook.ts
@@ -37,7 +37,7 @@ export const useImportRemoteFile = () => {
             appDispatch({ payload: { fileUrl: csvUrl }, type: "setFileUrl" });
             if (result) {
               const newSchedule = csvStringToSchedule(result);
-              await updateScheduleInContext(schedule, newSchedule, appDispatch);
+              await updateScheduleInContext(schedule, newSchedule, appDispatch, setIsCSVLoading);
               clearSearchParams();
             } else {
               setIsCSVLoading(false);
@@ -64,7 +64,7 @@ export const useImportRemoteFile = () => {
               const newSchedule = csvStringToSchedule(
                 getCSVFromXLSXData(result as ArrayBufferLike),
               );
-              await updateScheduleInContext(schedule, newSchedule, appDispatch);
+              await updateScheduleInContext(schedule, newSchedule, appDispatch, setIsCSVLoading);
               clearSearchParams();
             } else {
               setIsCSVLoading(false);

--- a/client-course-schedulizer/src/utilities/hooks/importRemoteFileHook.ts
+++ b/client-course-schedulizer/src/utilities/hooks/importRemoteFileHook.ts
@@ -37,12 +37,10 @@ export const useImportRemoteFile = () => {
             appDispatch({ payload: { fileUrl: csvUrl }, type: "setFileUrl" });
             if (result) {
               const newSchedule = csvStringToSchedule(result);
-              await updateScheduleInContext(schedule, newSchedule, appDispatch, setIsCSVLoading);
-              clearSearchParams();
-            } else {
-              setIsCSVLoading(false);
-              clearSearchParams();
+              await updateScheduleInContext(schedule, newSchedule, appDispatch);
             }
+            clearSearchParams();
+            setIsCSVLoading(false);
           });
       } else {
         clearSearchParams();
@@ -64,12 +62,10 @@ export const useImportRemoteFile = () => {
               const newSchedule = csvStringToSchedule(
                 getCSVFromXLSXData(result as ArrayBufferLike),
               );
-              await updateScheduleInContext(schedule, newSchedule, appDispatch, setIsCSVLoading);
-              clearSearchParams();
-            } else {
-              setIsCSVLoading(false);
-              clearSearchParams();
+              await updateScheduleInContext(schedule, newSchedule, appDispatch);
             }
+            clearSearchParams();
+            setIsCSVLoading(false);
           });
       } else {
         clearSearchParams();

--- a/client-course-schedulizer/src/utilities/hooks/useImportFile.ts
+++ b/client-course-schedulizer/src/utilities/hooks/useImportFile.ts
@@ -56,13 +56,8 @@ export const useImportFile = (isAdditiveImport: boolean) => {
       scheduleJSON = csvStringToSchedule(scheduleString);
 
       appDispatch({ payload: { fileUrl: "" }, type: "setFileUrl" });
-      await updateScheduleInContext(
-        schedule,
-        scheduleJSON,
-        appDispatch,
-        setIsCSVLoading,
-        isAdditiveImport,
-      );
+      await updateScheduleInContext(schedule, scheduleJSON, appDispatch, isAdditiveImport);
+      setIsCSVLoading(false);
     };
   };
 
@@ -72,7 +67,7 @@ export const useImportFile = (isAdditiveImport: boolean) => {
 /**
  * Update the Schedule information in the context
  * @param currentSchedule
- * @param scheduleJSON
+ * @param newSchedule
  * @param appDispatch
  * @param setIsCSVLoading
  * @param isAdditiveImport
@@ -81,22 +76,20 @@ export const useImportFile = (isAdditiveImport: boolean) => {
  */
 export const updateScheduleInContext = async (
   currentSchedule: Schedule,
-  scheduleJSON: Schedule,
+  newSchedule: Schedule,
   appDispatch: AppContext["appDispatch"],
-  setIsCSVLoading: AppContext["setIsCSVLoading"],
   isAdditiveImport = false,
 ) => {
-  if (!isEqual(currentSchedule, scheduleJSON)) {
+  if (!isEqual(currentSchedule, newSchedule)) {
     let newScheduleData: Schedule;
     if (isAdditiveImport) {
       newScheduleData = {
-        courses: [...new Set([...currentSchedule.courses, ...scheduleJSON.courses])],
+        courses: [...new Set([...currentSchedule.courses, ...newSchedule.courses])],
       };
     } else {
-      newScheduleData = scheduleJSON;
+      newScheduleData = newSchedule;
     }
     await appDispatch({ payload: { schedule: newScheduleData }, type: "setScheduleData" });
-    setIsCSVLoading(false);
   }
 };
 

--- a/client-course-schedulizer/src/utilities/hooks/useImportFile.ts
+++ b/client-course-schedulizer/src/utilities/hooks/useImportFile.ts
@@ -55,7 +55,7 @@ export const useImportFile = (isAdditiveImport: boolean) => {
       }
       scheduleJSON = csvStringToSchedule(scheduleString);
 
-      appDispatch({ payload: { fileUrl: "" }, type: "setFileUrl" });
+      !isAdditiveImport && appDispatch({ payload: { fileUrl: "" }, type: "setFileUrl" });
       await updateScheduleInContext(schedule, scheduleJSON, appDispatch, isAdditiveImport);
       setIsCSVLoading(false);
     };

--- a/client-course-schedulizer/src/utilities/hooks/useImportFile.ts
+++ b/client-course-schedulizer/src/utilities/hooks/useImportFile.ts
@@ -56,8 +56,13 @@ export const useImportFile = (isAdditiveImport: boolean) => {
       scheduleJSON = csvStringToSchedule(scheduleString);
 
       appDispatch({ payload: { fileUrl: "" }, type: "setFileUrl" });
-      await updateScheduleInContext(schedule, scheduleJSON, appDispatch, isAdditiveImport);
-      setIsCSVLoading(false);
+      await updateScheduleInContext(
+        schedule,
+        scheduleJSON,
+        appDispatch,
+        setIsCSVLoading,
+        isAdditiveImport,
+      );
     };
   };
 
@@ -69,6 +74,7 @@ export const useImportFile = (isAdditiveImport: boolean) => {
  * @param currentSchedule
  * @param scheduleJSON
  * @param appDispatch
+ * @param setIsCSVLoading
  * @param isAdditiveImport
  *
  * Ref: https://stackoverflow.com/a/57214316/9931154
@@ -77,6 +83,7 @@ export const updateScheduleInContext = async (
   currentSchedule: Schedule,
   scheduleJSON: Schedule,
   appDispatch: AppContext["appDispatch"],
+  setIsCSVLoading: AppContext["setIsCSVLoading"],
   isAdditiveImport = false,
 ) => {
   if (!isEqual(currentSchedule, scheduleJSON)) {
@@ -89,6 +96,7 @@ export const updateScheduleInContext = async (
       newScheduleData = scheduleJSON;
     }
     await appDispatch({ payload: { schedule: newScheduleData }, type: "setScheduleData" });
+    setIsCSVLoading(false);
   }
 };
 


### PR DESCRIPTION
Adds the ability for a user to add a schedule to the current working schedule. 

To test
- Upload one schedule with `Import New Schedule`
- Add a second schedule with `Add Schedule`
- Click on the Teaching Loads tab so you can easily see the combined schedules
- Upload the same schedule a second time and check the Teaching Loads to see that duplicates are not added. 

Also

- Removes awaits that are not needed on appDispatch calls. They are just needed when doing things when rendering the calendars (I think). Using awaits results in things being rendered twice. 
- Removes redundant code in the UseImportButton hook.

Thanks for the comments and critques!

Closes #49 