### PR TITLE
persist tab state

### DIFF
--- a/client-course-schedulizer/src/components/Tabs/Tabs.tsx
+++ b/client-course-schedulizer/src/components/Tabs/Tabs.tsx
@@ -7,18 +7,18 @@ import { Harmony } from "./Harmony";
 import { CSVActions, NoCoursesHeader, TabPanel } from "./tabComponents";
 import "./Tabs.scss";
 
-const DEFAULT_TAB = 0;
-
 /* A navigator between the different features of the app */
 export const Tabs = () => {
-  const [tabValue, setTabValue] = useState(DEFAULT_TAB);
   const {
-    appState: { schedule },
+    appState: { schedule, schedulizerTab },
     isCSVLoading,
+    appDispatch,
   } = useContext(AppContext);
+  const [tabValue, setTabValue] = useState(schedulizerTab);
 
   const handleTabChange = (event: ChangeEvent<{}>, newValue: number) => {
     setTabValue(newValue);
+    appDispatch({ payload: { schedulizerTab: newValue }, type: "setSchedulizerTab" });
   };
 
   const scheduleHasCourses = schedule.courses.length > 0;

--- a/client-course-schedulizer/src/components/Toolbar/SemesterSelector/SemesterSelector.tsx
+++ b/client-course-schedulizer/src/components/Toolbar/SemesterSelector/SemesterSelector.tsx
@@ -20,7 +20,7 @@ export const SemesterSelector = () => {
       // This action takes so long it affectively makes this
       //  synchronous function asynchronous.
       await appDispatch({
-        payload: { term: newTerm },
+        payload: { selectedTerm: newTerm },
         type: "setSelectedTerm",
       });
       setIsScheduleLoading(false);

--- a/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
@@ -16,6 +16,7 @@ export interface AppState {
   professors: string[];
   rooms: string[];
   schedule: Schedule;
+  schedulizerTab: number;
   selectedTerm: Term;
   slotMaxTime: string;
   slotMinTime: string;
@@ -31,6 +32,7 @@ export const initialAppState: AppState = loadLocal("appState") || {
   professors: [],
   rooms: [],
   schedule: { courses: [] },
+  schedulizerTab: 0,
   selectedTerm: Term.Fall,
   slotMaxTime: "22:00",
   slotMinTime: "6:00",
@@ -38,11 +40,6 @@ export const initialAppState: AppState = loadLocal("appState") || {
 
 // structure of actions that can be sent to app dispatch
 export interface AppAction {
-  payload: {
-    colorBy?: ColorBy;
-    fileUrl?: string;
-    schedule?: Schedule;
-    term?: Term;
-  };
-  type: "setScheduleData" | "setSelectedTerm" | "setFileUrl" | "setColorBy"; // add | to add more actions in the future
+  payload: Partial<AppState>;
+  type: "setScheduleData" | "setSelectedTerm" | "setFileUrl" | "setColorBy" | "setSchedulizerTab"; // add | to add more actions in the future
 }

--- a/client-course-schedulizer/src/utilities/reducers/appReducer.ts
+++ b/client-course-schedulizer/src/utilities/reducers/appReducer.ts
@@ -2,6 +2,8 @@ import { voidFn } from "utilities";
 import { AppAction, AppState, ColorBy, Term } from "utilities/interfaces";
 import { getClasses, getMinAndMaxTimes, getProfs, getRooms } from "utilities/services";
 
+const DEFAULT_PAGE = 0;
+
 /*
   Provides a function to perform multiple setState updates
   at once that depend on each other.
@@ -28,9 +30,9 @@ export const reducer = (actionCallback: (item: AppState) => void = voidFn) => {
         break;
       }
       case "setSelectedTerm": {
-        let { term } = action.payload;
-        term = term || Term.Fall;
-        newState = { ...state, selectedTerm: term };
+        let { selectedTerm } = action.payload;
+        selectedTerm = selectedTerm || Term.Fall;
+        newState = { ...state, selectedTerm };
         break;
       }
       case "setFileUrl": {
@@ -43,6 +45,12 @@ export const reducer = (actionCallback: (item: AppState) => void = voidFn) => {
         let { colorBy } = action.payload;
         colorBy = colorBy || ColorBy.Level;
         newState = { ...state, colorBy };
+        break;
+      }
+      case "setSchedulizerTab": {
+        let { schedulizerTab } = action.payload;
+        schedulizerTab = schedulizerTab || DEFAULT_PAGE;
+        newState = { ...state, schedulizerTab };
         break;
       }
       default:


### PR DESCRIPTION
A little PR to keep the Schedulizer Tab state stored in localStorage to persist throughout sessions. Helps make the app easier to predict from the user's point of view. 

Thanks for the comments and critiques. 