### PR TITLE
Fix non-teaching load export bug

### DIFF
--- a/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
+++ b/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
@@ -80,7 +80,7 @@ export const termCallback = (value: string, { section }: CaseCallbackParams) => 
     });
     section.term = termsArr;
   } else {
-    section.term = termCase(value);
+    section.term = value === "" ? [] : termCase(value);
   }
 };
 
@@ -99,7 +99,7 @@ export const instructorCallback = (value: string, { section }: CaseCallbackParam
 };
 
 export const prefixCallback = (value: string, { course }: CaseCallbackParams) => {
-  course.prefixes = prefixCase(value);
+  course.prefixes = value === "" ? [] : prefixCase(value);
 };
 
 export const nameCallback = (value: string, { course }: CaseCallbackParams) => {

--- a/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/writeCSV.ts
@@ -74,6 +74,9 @@ export const scheduleToNonTeachingCSVString = (schedule: Schedule): string => {
 
 export const getTermsStr = (section: Section): string => {
   if (Array.isArray(section.term)) {
+    if (section.term.length === 0) {
+      return "";
+    }
     let termsStr = '"';
     forEach(section.term, (term) => {
       termsStr += `${getTermStr(section.year, term)}, `;


### PR DESCRIPTION
This fixes the issues specified in #142. To test, import a schedule and create many non-teaching load activities (more than 1 for a professor, some with no term, etc.). Then, export and reimport the schedule. The non-teaching loads should work exactly as they did before the export. I believe the issue with all the non-teaching loads importing with the same load hours was fixed with #151.