### PR TITLE
Set name and department on update

### DIFF
--- a/client-course-schedulizer/csv/math-schedule-export.csv
+++ b/client-course-schedulizer/csv/math-schedule-export.csv
@@ -50,8 +50,8 @@ T","10:30AM - 11:20AM
 10:30AM - 11:20AM","Adv Linear Algebra","Todd Kapitula"
 19/FA,"MATH-359-A",3.00,2.00,"NH 294","TH","6:00PM - 9:00PM","Sem: Sec Teaching of Math","David Klanderman"
 19/FA,"MATH-361-A",4.00,4.00,"NH 251","MTWF","12:30PM - 1:20PM","Real Analysis I","John Ferdinands"
-20/IN,"MATH-390-A",3.00,0.00,"","","","Modeling of Angiogenesis","Todd Kapitula"
-19/FA,"MATH-390-A",1.00,0.00,"","","","Modeling of Angiogenesis","Christopher Moseley"
+20/IN,"MATH-390-A",3.00,0.00,"","","","Galois Theory","Todd Kapitula"
+19/FA,"MATH-390-A",1.00,0.00,"","","","Galois Theory","Christopher Moseley"
 20/SP,"MATH-391-A",0.00,1.00,"NH 276","TH","3:30PM - 4:20PM","Colloquium","David Klanderman
 Christopher Moseley"
 19/FA,"MATH-391-A",0.00,1.00,"NH 276","TH","3:30PM - 4:30PM","Colloquium","David Klanderman

--- a/client-course-schedulizer/csv/math-schedule-full-export.csv
+++ b/client-course-schedulizer/csv/math-schedule-full-export.csv
@@ -63,8 +63,8 @@ T","W
 ","Adv Linear Algebra","Todd Kapitula","Active","LEC",""
 "Mathematics and Statistics",19/FA,9/3/2019,2019,"MATH-359-A","MATH",359,A,300,3,2,3,3,45,45,"16","NH 294","TH","6:00PM - 9:00PM",9/3/2019,12/17/2019,Full,"NH","294","6:00 PM","18:00:00","180","9:00 PM","21:00:00","","","","TH","","Sem: Sec Teaching of Math","David Klanderman","Active","LEC",""
 "Mathematics and Statistics",19/FA,9/3/2019,2019,"MATH-361-A","MATH",361,A,300,4,4,28,28,45,45,"32","NH 251","MTWF","12:30PM - 1:20PM",9/3/2019,12/17/2019,Full,"NH","251","12:30 PM","12:30:00","50","1:20 PM","13:20:00","M","T","W","","F","Real Analysis I","John Ferdinands","Active","LEC",""
-"Mathematics and Statistics",20/IN,1/8/2020,2019,"MATH-390-A","MATH",390,A,300,3,0,1,0,1,0,"","","","",1/8/2020,1/28/2020,A,"","","","","","","","","","","","","Modeling of Angiogenesis","Todd Kapitula","Active","IND",""
-"Mathematics and Statistics",19/FA,9/3/2019,2019,"MATH-390-A","MATH",390,A,300,1,0,1,0,1,0,"","","","",9/3/2019,12/17/2019,Full,"","","","","","","","","","","","","Modeling of Angiogenesis","Christopher Moseley","Active","IND",""
+"Mathematics and Statistics",20/IN,1/8/2020,2019,"MATH-390-A","MATH",390,A,300,3,0,1,0,1,0,"","","","",1/8/2020,1/28/2020,A,"","","","","","","","","","","","","Galois Theory","Todd Kapitula","Active","IND",""
+"Mathematics and Statistics",19/FA,9/3/2019,2019,"MATH-390-A","MATH",390,A,300,1,0,1,0,1,0,"","","","",9/3/2019,12/17/2019,Full,"","","","","","","","","","","","","Galois Theory","Christopher Moseley","Active","IND",""
 "Mathematics and Statistics",20/SP,2/3/2020,2019,"MATH-391-A","MATH",391,A,300,0,1,27,0,47,0,"44","NH 276","TH","3:30PM - 4:20PM",2/3/2020,5/21/2020,Full,"NH","276","3:30 PM","15:30:00","50","4:20 PM","16:20:00","","","","TH","","Colloquium","David Klanderman
 Christopher Moseley","Active","SEM",""
 "Mathematics and Statistics",19/FA,9/3/2019,2019,"MATH-391-A","MATH",391,A,300,0,1,18,18,45,45,"44","NH 276","TH","3:30PM - 4:30PM",9/3/2019,12/17/2019,Full,"NH","276","3:30 PM","15:30:00","60","4:30 PM","16:30:00","","","","TH","","Colloquium","David Klanderman

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -154,6 +154,9 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
       section.instructors,
     );
 
+    schedule.courses[existingCourseIndex].name = course.name;
+    schedule.courses[existingCourseIndex].department = course.department;
+
     // If there is, add the new meeting(s) to the existing course
     if (existingSection) {
       const existingSectionIndex = schedule.courses[existingCourseIndex].sections.indexOf(


### PR DESCRIPTION
Fixes a bug where name and department would not update. To test, click on a section and edit its name and department. Then, click on the same section again or any section from the same course and the changes should have persisted.