### PR TITLE
Add instructional method to existing section check

### DIFF
--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -152,6 +152,7 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
       section.letter,
       section.term,
       section.instructors,
+      section.instructionalMethod,
     );
 
     // If there is, add the new meeting(s) to the existing course

--- a/client-course-schedulizer/src/utilities/services/addSectionService.ts
+++ b/client-course-schedulizer/src/utilities/services/addSectionService.ts
@@ -117,13 +117,15 @@ export const getSection = (
   letter: Section["letter"],
   term: Section["term"],
   instructors: Section["instructors"],
+  instructionalMethod: Section["instructionalMethod"],
 ) => {
   const course = getCourse(schedule, prefixes, courseNumber);
   const sections = filter(course?.sections, (section) => {
     return (
       section.letter === letter &&
       section.term === term &&
-      isEqual(section.instructors, instructors)
+      isEqual(section.instructors, instructors) &&
+      section.instructionalMethod === instructionalMethod
     );
   });
   return sections.length > 0 ? sections[0] : undefined;


### PR DESCRIPTION
This should fix the bug where some non-teaching loads are dropped on import if a professor has multiple non-teaching loads for the same term. Instructional method is important because it is the field where the activity name of a non-teaching load is stored. The issue before was that 2 non-teching loads for the same term and professor were looking like a duplicate and being removed. By checking instructional method as well, 2 non-teaching loads will not be considered duplicates unless they have the same instructor, term, and activity. Please test this a bunch to make sure there are no more issues.