### PR TITLE
Fix some issues with autocomplete

### DIFF
--- a/client-course-schedulizer/src/components/reuseables/AddNonTeachingLoadPopover/AddNonTeachingLoadPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddNonTeachingLoadPopover/AddNonTeachingLoadPopover.tsx
@@ -70,7 +70,12 @@ export const AddNonTeachingLoadPopover = ({ values }: PopoverValueProps) => {
           <GridItemTextField label="Activity" />
         </Grid>
         <Grid container spacing={SPACING}>
-          <GridItemAutocomplete label="Instructor" multiple options={[...professors].sort()} />
+          <GridItemAutocomplete
+            defaultValue={values?.section.instructors}
+            label="Instructor"
+            multiple
+            options={[...professors].sort()}
+          />
         </Grid>
         <Grid container spacing={SPACING}>
           <GridItemTextField label="Faculty Hours" />

--- a/client-course-schedulizer/src/components/reuseables/GridItem/GridItemAutocomplete/GridItemAutocomplete.tsx
+++ b/client-course-schedulizer/src/components/reuseables/GridItem/GridItemAutocomplete/GridItemAutocomplete.tsx
@@ -31,14 +31,18 @@ export const GridItemAutocomplete = (
             return data;
           }}
           render={({ onChange, ...controllerProps }) => {
-            const cPropSet = new Set(controllerProps.value);
+            const cPropSet = new Set(
+              Array.isArray(controllerProps.value)
+                ? controllerProps.value
+                : [controllerProps.value],
+            );
             const propsCopy = { ...props };
             // Remove existing elements from the autocomplete options
             // Set difference: https://stackoverflow.com/a/36504668/14478665
             propsCopy.options = [
               ...new Set(
                 props.options.filter((x) => {
-                  return !cPropSet.has(x);
+                  return x && !cPropSet.has(x);
                 }),
               ),
             ];
@@ -49,6 +53,7 @@ export const GridItemAutocomplete = (
                 onChange={(e, data) => {
                   return onChange(data);
                 }}
+                openOnFocus
                 renderInput={(params) => {
                   return (
                     <TextField

--- a/client-course-schedulizer/src/components/reuseables/GridItem/GridItemAutocomplete/GridItemAutocomplete.tsx
+++ b/client-course-schedulizer/src/components/reuseables/GridItem/GridItemAutocomplete/GridItemAutocomplete.tsx
@@ -33,6 +33,7 @@ export const GridItemAutocomplete = (
           render={({ onChange, ...controllerProps }) => {
             return (
               <Autocomplete
+                autoSelect
                 freeSolo
                 onChange={(e, data) => {
                   return onChange(data);

--- a/client-course-schedulizer/src/components/reuseables/GridItem/GridItemAutocomplete/GridItemAutocomplete.tsx
+++ b/client-course-schedulizer/src/components/reuseables/GridItem/GridItemAutocomplete/GridItemAutocomplete.tsx
@@ -18,7 +18,7 @@ export const GridItemAutocomplete = (
 ) => {
   const { defaultValue, label, name } = props;
   const { control, errors } = useFormContext();
-  const { name: nameFallback } = useInput(label, errors);
+  const { name: nameFallback, errorMessage } = useInput(label, errors);
 
   return (
     <Grid container direction="column" item xs>
@@ -31,6 +31,17 @@ export const GridItemAutocomplete = (
             return data;
           }}
           render={({ onChange, ...controllerProps }) => {
+            const cPropSet = new Set(controllerProps.value);
+            const propsCopy = { ...props };
+            // Remove existing elements from the autocomplete options
+            // Set difference: https://stackoverflow.com/a/36504668/14478665
+            propsCopy.options = [
+              ...new Set(
+                props.options.filter((x) => {
+                  return !cPropSet.has(x);
+                }),
+              ),
+            ];
             return (
               <Autocomplete
                 autoSelect
@@ -39,9 +50,17 @@ export const GridItemAutocomplete = (
                   return onChange(data);
                 }}
                 renderInput={(params) => {
-                  return <TextField label={label} {...params} variant="outlined" />;
+                  return (
+                    <TextField
+                      label={label}
+                      {...params}
+                      error={!!errorMessage}
+                      helperText={errorMessage}
+                      variant="outlined"
+                    />
+                  );
                 }}
-                {...props}
+                {...propsCopy}
                 {...controllerProps}
               />
             );

--- a/client-course-schedulizer/src/utilities/services/addNonTeachingLoadService.ts
+++ b/client-course-schedulizer/src/utilities/services/addNonTeachingLoadService.ts
@@ -12,7 +12,7 @@ export const mapNonTeachingLoadValuesToInput = (
   return {
     activity: data?.section.instructionalMethod ?? "",
     facultyHours: data?.section.facultyHours,
-    instructor: data?.section.instructors[0] ?? "",
+    instructor: data?.section.instructors ?? [],
     terms,
   };
 };
@@ -22,7 +22,7 @@ export const mapNonTeachingLoadInput = (data: NonTeachingLoadInput) => {
   const newCourse: Course = cloneDeep(emptyCourse);
   newSection.instructionalMethod = data.activity;
   newSection.facultyHours = data.facultyHours;
-  newSection.instructors = [data.instructor];
+  newSection.instructors = data.instructor;
   newSection.isNonTeaching = true;
   newSection.term = data.terms as Term[];
   return { newCourse, newSection };

--- a/client-course-schedulizer/src/utilities/services/addSectionService.ts
+++ b/client-course-schedulizer/src/utilities/services/addSectionService.ts
@@ -55,7 +55,7 @@ export interface SectionInput {
 export interface NonTeachingLoadInput {
   activity: Section["instructionalMethod"];
   facultyHours: Section["facultyHours"];
-  instructor: Instructor;
+  instructor: Instructor[];
   terms: CheckboxTerms;
 }
 

--- a/client-course-schedulizer/src/utilities/services/addSectionService.ts
+++ b/client-course-schedulizer/src/utilities/services/addSectionService.ts
@@ -184,7 +184,7 @@ export const mapInternalTypesToInput = (data?: CourseSectionMeeting): SectionInp
       ? data?.section.semesterLength
       : SemesterLength.HalfFirst) as unknown) as Half,
     instructionalMethod: data?.section.instructionalMethod ?? "LEC",
-    instructor: data?.section.instructors || [],
+    instructor: data?.section.instructors ?? [],
     intensiveSemester: ((data?.section.semesterLength &&
     convertFromSemesterLength(data?.section.semesterLength) ===
       SemesterLengthOption.IntensiveSemester

--- a/client-course-schedulizer/src/utilities/services/validation/popover.ts
+++ b/client-course-schedulizer/src/utilities/services/validation/popover.ts
@@ -114,6 +114,6 @@ export const addNonTeachingLoadSchema = object().shape({
     .test("is-decimal", "invalid decimal", decimalRegex)
     .transform(emptyStringToNull)
     .nullable(),
-  instructor: string().required(),
+  instructor: array().of(string()).required(),
   terms: array().transform(removeUncheckedValues),
 });

--- a/client-course-schedulizer/src/utilities/services/validation/popover.ts
+++ b/client-course-schedulizer/src/utilities/services/validation/popover.ts
@@ -73,8 +73,8 @@ export const addSectionSchema = object().shape({
     .nullable(),
   location: string(),
   name: string(),
-  number: string().required(),
-  prefix: array().of(string().uppercase().required()),
+  number: string().required().typeError("number is a required field"),
+  prefix: array().of(string().uppercase()).required().typeError("prefix is a required field"),
   roomCapacity: number()
     .typeError("room capacity must be a number")
     .positive()
@@ -82,7 +82,7 @@ export const addSectionSchema = object().shape({
     .min(0)
     .transform(emptyStringToNull)
     .nullable(),
-  section: string().required().uppercase(),
+  section: string().required().uppercase().typeError("section is a required field"),
   status: string(),
   studentHours: number()
     .typeError("student hours must be a number")


### PR DESCRIPTION
This PR fixes 1 and 2 of issue #167. The first was fixed simply by adding the autoSelect prop to the Autocomplete which adds the current value when the Autocomplete loses focus. The second was fixed by making `instructor` an array in `NonTeachingLoadInput`. It also fixes a bug where the instructor was not passed to the non-teaching load form when editting.