### PR TITLE
Add Red Border Around Conflicts

### DIFF
--- a/client-course-schedulizer/package-lock.json
+++ b/client-course-schedulizer/package-lock.json
@@ -28,6 +28,7 @@
         "material-ui-image": "3.3.1",
         "material-ui-popup-state": "^1.7.0",
         "moment": "2.29.1",
+        "moment-range": "^4.0.2",
         "node-sass": "4.14.1",
         "object-hash": "^2.1.1",
         "papaparse": "^5.3.0",
@@ -4692,7 +4693,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5901,7 +5901,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -6688,7 +6687,6 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
       "dependencies": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -6699,7 +6697,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -6710,7 +6707,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -7729,7 +7725,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dev": true,
       "dependencies": {
         "type": "^2.0.0"
       }
@@ -7737,8 +7732,7 @@
     "node_modules/ext/node_modules/type": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
-      "dev": true
+      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -10771,7 +10765,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -13126,6 +13119,20 @@
         "node": "*"
       }
     },
+    "node_modules/moment-range": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-4.0.2.tgz",
+      "integrity": "sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==",
+      "dependencies": {
+        "es6-symbol": "^3.1.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "moment": ">= 2"
+      }
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -13237,8 +13244,7 @@
     "node_modules/next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -16489,7 +16495,6 @@
         "eslint-plugin-react-hooks": "^1.6.1",
         "file-loader": "4.3.0",
         "fs-extra": "^8.1.0",
-        "fsevents": "2.1.2",
         "html-webpack-plugin": "4.0.0-beta.11",
         "identity-obj-proxy": "3.0.0",
         "jest": "24.9.0",
@@ -19805,8 +19810,7 @@
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -20263,8 +20267,7 @@
       "dependencies": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "watchpack-chokidar2": "^2.0.0"
@@ -20561,7 +20564,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -26650,7 +26652,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -27349,7 +27350,6 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -27360,7 +27360,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -27371,7 +27370,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -28212,7 +28210,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dev": true,
       "requires": {
         "type": "^2.0.0"
       },
@@ -28220,8 +28217,7 @@
         "type": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
-          "dev": true
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
         }
       }
     },
@@ -32647,6 +32643,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
+    "moment-range": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-4.0.2.tgz",
+      "integrity": "sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==",
+      "requires": {
+        "es6-symbol": "^3.1.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -32748,8 +32752,7 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -38335,8 +38338,7 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -56,6 +56,7 @@
     "material-ui-image": "3.3.1",
     "material-ui-popup-state": "^1.7.0",
     "moment": "2.29.1",
+    "moment-range": "^4.0.2",
     "node-sass": "4.14.1",
     "object-hash": "^2.1.1",
     "papaparse": "^5.3.0",

--- a/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
+++ b/client-course-schedulizer/src/components/reuseables/Calendar/Calendar.scss
@@ -11,3 +11,7 @@
 .fc-event-title {
   font-size: 0.7vw;
 }
+
+.fc-event {
+  border-width: 0.12vw;
+}

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -8,6 +8,7 @@ import StickyNode from "react-stickynode";
 import { CourseSectionMeeting } from "utilities";
 import { AppContext, ScheduleContext } from "utilities/contexts";
 import {
+  colorConflictBorders,
   colorEventsByFeature,
   filterEventsByTerm,
   filterHeadersWithNoEvents,
@@ -85,6 +86,7 @@ const ScheduleBase = ({ calendarHeaders, groupedEvents, ...calendarOptions }: Sc
 
   // Color events by the selected feature
   colorEventsByFeature(filteredEvents, colorBy);
+  colorConflictBorders(groupedEvents);
 
   return (
     <>

--- a/client-course-schedulizer/src/utilities/constants.ts
+++ b/client-course-schedulizer/src/utilities/constants.ts
@@ -15,6 +15,7 @@ export const emptyCourse: Course = {
 export const emptyMeeting: Meeting = {
   days: [],
   duration: 0,
+  isConflict: false,
   location: { building: "", roomCapacity: 0, roomNumber: "" },
   startTime: "",
 };

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/scheduleInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/scheduleInterfaces.ts
@@ -12,6 +12,7 @@ export interface Meeting {
   days: Day[];
   // In minutes (usually 50)
   duration: number;
+  isConflict?: boolean;
   location: Location;
   // Like "8:00 AM" or "12:30 PM"
   startTime: string;

--- a/client-course-schedulizer/src/utilities/services/conflictsService.ts
+++ b/client-course-schedulizer/src/utilities/services/conflictsService.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, forEach } from "lodash";
+import { forEach } from "lodash";
 import * as AllMoment from "moment";
 import moment, { Moment } from "moment";
 import { extendMoment } from "moment-range";
@@ -16,11 +16,10 @@ interface ConflictData {
   term: Section["term"];
 }
 
-export const findConflicts = (origSchedule: Schedule): Schedule => {
+export const findConflicts = (schedule: Schedule): Schedule => {
   // flatten the schedule into a single array with just the data to check for conflicts
   const dataToCheck: ConflictData[] = [];
-  const scheduleWithConflicts = cloneDeep(origSchedule);
-  forEach(origSchedule.courses, (course, courseIndex) => {
+  forEach(schedule.courses, (course, courseIndex) => {
     forEach(course.sections, (section, sectionIndex) => {
       forEach(section.meetings, (meeting, meetingIndex) => {
         const startTimeMoment = moment(meeting.startTime, "h:mm A");
@@ -36,7 +35,7 @@ export const findConflicts = (origSchedule: Schedule): Schedule => {
       });
     });
   });
-  console.log(dataToCheck);
+
   // loop through each pair of meetings and mark conflicts
   forEach(dataToCheck, (meeting1, i) => {
     forEach(dataToCheck, (meeting2, j) => {
@@ -58,11 +57,11 @@ export const findConflicts = (origSchedule: Schedule): Schedule => {
         ) {
           const [ci1, si1, mi1] = meeting1.indexes;
           const [ci2, si2, mi2] = meeting2.indexes;
-          scheduleWithConflicts.courses[ci1].sections[si1].meetings[mi1].isConflict = true;
-          scheduleWithConflicts.courses[ci2].sections[si2].meetings[mi2].isConflict = true;
+          schedule.courses[ci1].sections[si1].meetings[mi1].isConflict = true;
+          schedule.courses[ci2].sections[si2].meetings[mi2].isConflict = true;
         }
       }
     });
   });
-  return scheduleWithConflicts;
+  return schedule;
 };

--- a/client-course-schedulizer/src/utilities/services/conflictsService.ts
+++ b/client-course-schedulizer/src/utilities/services/conflictsService.ts
@@ -1,0 +1,68 @@
+import { cloneDeep, forEach } from "lodash";
+import * as AllMoment from "moment";
+import moment, { Moment } from "moment";
+import { extendMoment } from "moment-range";
+import { Day, Schedule, Section } from "utilities";
+
+const { range } = extendMoment(AllMoment);
+
+interface ConflictData {
+  days: Day[];
+  endTime: Moment;
+  indexes: number[];
+  instructors: Section["instructors"];
+  room: string;
+  startTime: Moment;
+  term: Section["term"];
+}
+
+export const findConflicts = (origSchedule: Schedule): Schedule => {
+  // flatten the schedule into a single array with just the data to check for conflicts
+  const dataToCheck: ConflictData[] = [];
+  const scheduleWithConflicts = cloneDeep(origSchedule);
+  forEach(origSchedule.courses, (course, courseIndex) => {
+    forEach(course.sections, (section, sectionIndex) => {
+      forEach(section.meetings, (meeting, meetingIndex) => {
+        const startTimeMoment = moment(meeting.startTime, "h:mm A");
+        dataToCheck.push({
+          days: meeting.days,
+          endTime: moment(startTimeMoment).add(meeting.duration, "minutes"),
+          indexes: [courseIndex, sectionIndex, meetingIndex],
+          instructors: section.instructors,
+          room: `${meeting.location.building} ${meeting.location.roomNumber}`,
+          startTime: startTimeMoment,
+          term: section.term,
+        });
+      });
+    });
+  });
+  console.log(dataToCheck);
+  // loop through each pair of meetings and mark conflicts
+  forEach(dataToCheck, (meeting1, i) => {
+    forEach(dataToCheck, (meeting2, j) => {
+      const range1 = range(meeting1.startTime, meeting1.endTime);
+      const range2 = range(meeting2.startTime, meeting2.endTime);
+      if (
+        i !== j &&
+        range1.overlaps(range2) &&
+        meeting1.term === meeting2.term &&
+        meeting1.days.some((day) => {
+          return meeting2.days.includes(day);
+        })
+      ) {
+        if (
+          meeting1.instructors.some((instructor) => {
+            return meeting2.instructors.includes(instructor);
+          }) ||
+          meeting1.room === meeting2.room
+        ) {
+          const [ci1, si1, mi1] = meeting1.indexes;
+          const [ci2, si2, mi2] = meeting2.indexes;
+          scheduleWithConflicts.courses[ci1].sections[si1].meetings[mi1].isConflict = true;
+          scheduleWithConflicts.courses[ci2].sections[si2].meetings[mi2].isConflict = true;
+        }
+      }
+    });
+  });
+  return scheduleWithConflicts;
+};

--- a/client-course-schedulizer/src/utilities/services/conflictsService.ts
+++ b/client-course-schedulizer/src/utilities/services/conflictsService.ts
@@ -22,6 +22,7 @@ export const findConflicts = (schedule: Schedule): Schedule => {
   forEach(schedule.courses, (course, courseIndex) => {
     forEach(course.sections, (section, sectionIndex) => {
       forEach(section.meetings, (meeting, meetingIndex) => {
+        meeting.isConflict = false;
         const startTimeMoment = moment(meeting.startTime, "h:mm A");
         dataToCheck.push({
           days: meeting.days,

--- a/client-course-schedulizer/src/utilities/services/index.ts
+++ b/client-course-schedulizer/src/utilities/services/index.ts
@@ -1,5 +1,6 @@
 export * from "./addNonTeachingLoadService";
 export * from "./addSectionService";
+export * from "./conflictsService";
 export * from "./facultyLoadsService";
 export * from "./facultyScheduleService";
 export * from "./harmoniouslyService";


### PR DESCRIPTION
This PR adds a red border for all meetings that have conflicting instructors or rooms. 
To test:
- Import the math-schedule. It should have a red border around the MATH-270 and MATH-271 sections since they look like a conflict.
- Change the color by and make sure the border stays
- Add a new section that conflicts with a professor's schedule. It should have a red border once added. 
- Check the room schedule and notice that the section you added also has a red border there (so users can see if there are room conflicts from the faculty view or instructor conflicts from the room view)
- Update it to a time that does not conflict and notice that the border goes away
- Test some of the edge cases such as multiple instructors, same time but different days, same time but different term, etc.

The next step will be to add this information to the Conflicts tab.