### PR TITLE
Improvement/reduce scrolling

### DIFF
--- a/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/DepartmentSchedule.scss
+++ b/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/DepartmentSchedule.scss
@@ -1,0 +1,3 @@
+.department-calendar-width {
+  width: 1400px !important;
+}

--- a/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/DepartmentSchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/DepartmentSchedule.tsx
@@ -16,6 +16,7 @@ export const DepartmentSchedule = () => {
       <Schedule
         calendarHeaders={departments.sort()}
         groupedEvents={getEvents(schedule, "department")}
+        scheduleType="department"
       />
     </>
   );

--- a/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/DepartmentSchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/DepartmentSchedule.tsx
@@ -1,0 +1,22 @@
+import { Schedule } from "components";
+import React, { useContext } from "react";
+import { getEvents } from "utilities";
+import { AppContext } from "utilities/contexts";
+import "./DepartmentSchedule.scss";
+
+/* Creates a list of Calendars to create the Department Schedule
+ */
+export const DepartmentSchedule = () => {
+  const {
+    appState: { departments, schedule },
+  } = useContext(AppContext);
+
+  return (
+    <>
+      <Schedule
+        calendarHeaders={departments.sort()}
+        groupedEvents={getEvents(schedule, "department")}
+      />
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/index.ts
+++ b/client-course-schedulizer/src/components/Tabs/DepartmentSchedule/index.ts
@@ -1,0 +1,1 @@
+export * from "./DepartmentSchedule";

--- a/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/FacultySchedule/FacultySchedule.tsx
@@ -16,6 +16,7 @@ export const FacultySchedule = () => {
       <Schedule
         calendarHeaders={professors.sort()}
         groupedEvents={getEvents(schedule, "faculty")}
+        scheduleType="faculty"
       />
     </>
   );

--- a/client-course-schedulizer/src/components/Tabs/RoomsSchedule/RoomsSchedule.tsx
+++ b/client-course-schedulizer/src/components/Tabs/RoomsSchedule/RoomsSchedule.tsx
@@ -10,7 +10,11 @@ export const RoomsSchedule = () => {
 
   return (
     <>
-      <Schedule calendarHeaders={rooms.sort()} groupedEvents={getEvents(schedule, "room")} />
+      <Schedule
+        calendarHeaders={rooms.sort()}
+        groupedEvents={getEvents(schedule, "room")}
+        scheduleType="room"
+      />
     </>
   );
 };

--- a/client-course-schedulizer/src/components/Tabs/Tabs.tsx
+++ b/client-course-schedulizer/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import { Container, Tab, Tabs as MUITabs } from "@material-ui/core";
 import { AsyncComponent } from "components";
-import { FacultyLoads, FacultySchedule, RoomsSchedule } from "components/Tabs";
+import { DepartmentSchedule, FacultyLoads, FacultySchedule, RoomsSchedule } from "components/Tabs";
 import React, { ChangeEvent, useContext, useState } from "react";
 import { AppContext } from "utilities/contexts";
 import { SchedulizerTab } from "utilities/interfaces";
@@ -41,6 +41,7 @@ export const Tabs = () => {
               >
                 <Tab label="Faculty Schedule" />
                 <Tab label="Room Schedule" />
+                <Tab label="Dept Schedule" />
                 <Tab label="Teaching Loads" />
                 <Tab label="Conflicts" />
               </MUITabs>
@@ -53,9 +54,12 @@ export const Tabs = () => {
               <RoomsSchedule />
             </TabPanel>
             <TabPanel index={2} value={tabValue}>
-              <FacultyLoads />
+              <DepartmentSchedule />
             </TabPanel>
             <TabPanel index={3} value={tabValue}>
+              <FacultyLoads />
+            </TabPanel>
+            <TabPanel index={4} value={tabValue}>
               Item Four
             </TabPanel>
           </>

--- a/client-course-schedulizer/src/components/Tabs/index.ts
+++ b/client-course-schedulizer/src/components/Tabs/index.ts
@@ -1,3 +1,4 @@
+export * from "./DepartmentSchedule";
 export * from "./FacultyLoads";
 export * from "./FacultySchedule";
 export * from "./RoomsSchedule";

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.scss
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.scss
@@ -16,7 +16,12 @@
 }
 
 .calendar-width {
-  width: 25vw;
+  width: 350px;
+}
+
+.fc-event-title,
+.fc-event-time {
+  font-size: 0.7em !important;
 }
 
 .calendar-title {

--- a/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/Schedule.tsx
@@ -20,6 +20,7 @@ import "./Schedule.scss";
 interface ScheduleBase extends CalendarOptions {
   calendarHeaders: string[];
   groupedEvents: GroupedEvents;
+  scheduleType: string;
 }
 
 /* Provides a Schedule component to handle loading and async events and interfaces
@@ -44,7 +45,12 @@ export const Schedule = (props: ScheduleBase) => {
   <Stick> is used to stick the Schedule Header to the Schedule
   to track horizontal scrolling.
 */
-const ScheduleBase = ({ calendarHeaders, groupedEvents, ...calendarOptions }: ScheduleBase) => {
+const ScheduleBase = ({
+  calendarHeaders,
+  groupedEvents,
+  scheduleType,
+  ...calendarOptions
+}: ScheduleBase) => {
   const {
     appState: { colorBy, selectedTerm, slotMaxTime, slotMinTime },
   } = useContext(AppContext);
@@ -95,13 +101,19 @@ const ScheduleBase = ({ calendarHeaders, groupedEvents, ...calendarOptions }: Sc
         <LeftTimeAxis {...times} />
         <div className="schedule-wrapper">
           <Stick
-            node={<ScheduleHeader headers={calenderHeadersNoEmptyInTerm} />}
+            node={
+              <ScheduleHeader headers={calenderHeadersNoEmptyInTerm} scheduleType={scheduleType} />
+            }
             position="top left"
           >
             <div className="adjacent">
               {calenderHeadersNoEmptyInTerm.map((header) => {
+                let className = "calendar-width hide-axis";
+                if (scheduleType === "department") {
+                  className += " department-calendar-width";
+                }
                 return (
-                  <div key={header} className="calendar-width hide-axis">
+                  <div key={header} className={className}>
                     <Calendar
                       {...calendarOptions}
                       key={header}
@@ -156,6 +168,7 @@ const LeftTimeAxis = ({ slotMinTime: min, slotMaxTime: max }: LeftTimeAxis) => {
 
 interface ScheduleHeader {
   headers: ScheduleBase["calendarHeaders"];
+  scheduleType: string;
 }
 
 const tenVH = window.innerHeight / 10;
@@ -164,13 +177,17 @@ const tenVH = window.innerHeight / 10;
   StickyHeader is used to keep the Schedule header sticky to the
   top of the view port.
 */
-const ScheduleHeader = ({ headers }: ScheduleHeader) => {
+const ScheduleHeader = ({ headers, scheduleType }: ScheduleHeader) => {
   return (
     <StickyNode top={tenVH}>
       <div className="adjacent schedule-header-row">
         {headers.map((header) => {
+          let className = "calendar-width calendar-title";
+          if (scheduleType === "department") {
+            className += " department-calendar-width";
+          }
           return (
-            <div key={header} className="calendar-width calendar-title">
+            <div key={header} className={className}>
               {header}
             </div>
           );

--- a/client-course-schedulizer/src/utilities/hooks/addSectionHooks.ts
+++ b/client-course-schedulizer/src/utilities/hooks/addSectionHooks.ts
@@ -118,7 +118,7 @@ const scrollToUpdatedSection = (newCourse: Course, newSection: Section) => {
     });
   });
   if (newElement && newElement.parentElement?.parentElement) {
-    newElement.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
+    newElement.scrollIntoView(false);
   }
 };
 

--- a/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
@@ -19,6 +19,7 @@ export enum SchedulizerTab {
 export interface AppState {
   classes: string[];
   colorBy: ColorBy;
+  departments: string[];
   fileUrl: string;
   professors: string[];
   rooms: string[];
@@ -30,11 +31,12 @@ export interface AppState {
 }
 
 // Defaults for the app state when it launches, will try to load
-//  previous appState (with cleared fileUrl) to launch app from.
+//  previous appState to launch app from.
 //  If no previous state saved, will default to the object below.
 export const initialAppState: AppState = loadLocal("appState") || {
   classes: [],
   colorBy: 0,
+  departments: [],
   fileUrl: "",
   professors: [],
   rooms: [],
@@ -44,6 +46,20 @@ export const initialAppState: AppState = loadLocal("appState") || {
   slotMaxTime: "22:00",
   slotMinTime: "6:00",
 };
+
+// Ensure that these aren't undefined if they didn't exist in the previous app state
+if (!initialAppState.classes) {
+  initialAppState.departments = [];
+}
+if (!initialAppState.departments) {
+  initialAppState.departments = [];
+}
+if (!initialAppState.professors) {
+  initialAppState.departments = [];
+}
+if (!initialAppState.rooms) {
+  initialAppState.departments = [];
+}
 
 // structure of actions that can be sent to app dispatch
 export interface AppAction {

--- a/client-course-schedulizer/src/utilities/reducers/appReducer.ts
+++ b/client-course-schedulizer/src/utilities/reducers/appReducer.ts
@@ -1,6 +1,6 @@
 import { voidFn } from "utilities";
 import { AppAction, AppState, ColorBy, SchedulizerTab, Term } from "utilities/interfaces";
-import { getClasses, getMinAndMaxTimes, getProfs, getRooms } from "utilities/services";
+import { getClasses, getDepts, getMinAndMaxTimes, getProfs, getRooms } from "utilities/services";
 
 /*
   Provides a function to perform multiple setState updates
@@ -19,6 +19,7 @@ export const reducer = (actionCallback: (item: AppState) => void = voidFn) => {
         newState = {
           ...state,
           classes: getClasses(schedule),
+          departments: getDepts(schedule),
           professors: getProfs(schedule),
           rooms: getRooms(schedule),
           schedule,

--- a/client-course-schedulizer/src/utilities/services/scheduleService.ts
+++ b/client-course-schedulizer/src/utilities/services/scheduleService.ts
@@ -32,18 +32,29 @@ const eventExistsInEventList = (event: EventInput, eventList: EventInput[]): boo
 };
 
 // TODO: Add events with no meeting times as all day
-export const getEvents = (schedule: Schedule, groups: "faculty" | "room"): GroupedEvents => {
+export const getEvents = (
+  schedule: Schedule,
+  groups: "faculty" | "room" | "department",
+): GroupedEvents => {
   const events: GroupedEvents = {};
   const days: Day[] = enumArray(Day);
   const scheduleWithConflicts = findConflicts(schedule);
   forEach(scheduleWithConflicts.courses, (course) => {
+    const dept = course.department;
     forEach(course.sections, (section) => {
       const sectionName = `${course.prefixes[0]}-${course.number}-${section.letter}`;
       forEach(section.instructors, (prof) => {
         forEach(section.meetings, (meeting) => {
           const room = `${meeting.location.building} ${meeting.location.roomNumber}`;
           const className = createEventClassName(sectionName, room, prof);
-          const group = groups === "faculty" ? prof : room;
+          let group = "";
+          if (groups === "faculty") {
+            group = prof;
+          } else if (groups === "room") {
+            group = room;
+          } else {
+            group = dept;
+          }
           const startTimeMoment = moment(meeting.startTime, "h:mm A");
           const endTimeMoment = moment(startTimeMoment).add(meeting.duration, "minutes");
           forEach(meeting.days, (day) => {
@@ -258,4 +269,14 @@ export const getInstructionalMethods = (schedule: Schedule) => {
     });
   });
   return instructionalMethods.sort();
+};
+
+export const getDepts = (schedule: Schedule) => {
+  const departments: string[] = [];
+  forEach(schedule.courses, (course) => {
+    if (!departments.includes(course.department)) {
+      departments.push(course.department ? course.department : "");
+    }
+  });
+  return departments.sort();
 };


### PR DESCRIPTION
This PR generally tries to make less scrolling required, to do so it:
1. Makes widths (and text sizes) of faculty/room schedules constant pixel sizes, so that in theory you should be able to fit 5 schedules instead of 4 on a page with a sufficiently wide monitor. Notice that when expanding the width of the browser window, the schedules stay the same width and more schedules are available.
2. Creates a `Department Schedule` tab which has the courses grouped by the faculty name (should be the same for all courses in the math schedule). These schedules are 4 times as wide, so that you can see the courses. This is intended to help dept chairs to see the entire schedule at a glance.

Things I would recommend testing:
1. Try on chrome, firefox, and safari (if possible).
2. You could try the department view for the `Course Section Enrollment.csv` which looks really cool to have all of the department schedules in a semi-efficient space. (In my experience, using this schedule can be really computationally intensive and switching from the `Faculty Schedule` tab to the `Department Schedule` tab will take a while.)

Closes #88