### PR TITLE
Feature/pretty harmony

### DIFF
--- a/client-course-schedulizer/src/components/Footer/Footer.tsx
+++ b/client-course-schedulizer/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Box, Grid } from "@material-ui/core";
+import { Box, Grid } from "@material-ui/core";
 import moment from "moment";
 import React from "react";
 import "./Footer.scss";
@@ -10,10 +10,10 @@ import "./Footer.scss";
 */
 export const Footer = () => {
   return (
-    <AppBar className="app-footer" elevation={0} position="static">
+    <footer className="app-footer">
       <Grid container justify="flex-start">
         <Box p={2}>© {moment().year()} Senior Knights</Box>
       </Grid>
-    </AppBar>
+    </footer>
   );
 };

--- a/client-course-schedulizer/src/components/pages/AboutPage/AboutPage.tsx
+++ b/client-course-schedulizer/src/components/pages/AboutPage/AboutPage.tsx
@@ -1,5 +1,5 @@
-import { Box, Grid, Typography } from "@material-ui/core";
-import { NewTabLink } from "components/reuseables";
+import { Grid } from "@material-ui/core";
+import { NewTabLink, Page } from "components/reuseables";
 import React from "react";
 import { team, TeamMember } from "utilities";
 import { TeamMemberProfile, TextSection } from ".";
@@ -9,17 +9,13 @@ import "./AboutPage.scss";
   with references */
 export const AboutPage = () => {
   return (
-    <Grid container justify="center">
-      <Typography align="left">
-        <Box maxWidth={900} mb={3} p={4}>
-          <AboutVision />
-          <AboutTeam />
-          <AboutCode />
-          <AboutReport />
-          <AboutResources />
-        </Box>
-      </Typography>
-    </Grid>
+    <Page>
+      <AboutVision />
+      <AboutTeam />
+      <AboutCode />
+      <AboutReport />
+      <AboutResources />
+    </Page>
   );
 };
 

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyAddAssignments.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyAddAssignments.tsx
@@ -10,7 +10,6 @@ export const HarmonyAddAssignments = () => {
   const courses = useHarmonyFormsStore(selector);
   return (
     <>
-      <h3>Add Assignments</h3>
       {(courses as HarmonyFormsAccessors["courses"]).map((courseObj) => {
         return <HarmonyCourseCheckboxes key={courseObj.Course} course={courseObj.Course} />;
       })}

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCheckbox.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCheckbox.tsx
@@ -32,8 +32,8 @@ export const HarmonyCheckbox = ({ setList, item }: HarmonyCheckboxProps) => {
   );
 
   return (
-    <div>
-      {item} <Checkbox checked={checked} onChange={handleChange(item)} />
+    <div style={{ alignItems: "center", display: "flex" }}>
+      <Checkbox checked={checked} onChange={handleChange(item)} /> {item}
     </div>
   );
 };

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCheckbox.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from "@material-ui/core";
+import { Checkbox, Grid } from "@material-ui/core";
 import React, { ChangeEvent, Dispatch, SetStateAction, useCallback, useState } from "react";
 
 interface HarmonyCheckboxProps {
@@ -32,8 +32,8 @@ export const HarmonyCheckbox = ({ setList, item }: HarmonyCheckboxProps) => {
   );
 
   return (
-    <div style={{ alignItems: "center", display: "flex" }}>
+    <Grid alignItems="center" container>
       <Checkbox checked={checked} onChange={handleChange(item)} /> {item}
-    </div>
+    </Grid>
   );
 };

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCheckboxList.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCheckboxList.tsx
@@ -19,15 +19,15 @@ export const HarmonyCheckboxList = <T extends unknown[]>({
   setList,
 }: HarmonyCheckboxListProps<T>) => {
   return (
-    <>
-      <h4>{id}</h4>
+    <div>
+      <h3>{id}</h3>
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       {list.map((itemObj: any) => {
         const item: string =
           (customLabel && customLabel(itemObj)) || itemObj[Object.keys(itemObj)[0]];
         return <HarmonyCheckbox key={`${item}-${course}`} item={item} setList={setList} />;
       })}
-    </>
+    </div>
   );
 };
 

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCourseCheckboxes.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCourseCheckboxes.tsx
@@ -1,4 +1,4 @@
-import { Box, Paper } from "@material-ui/core";
+import { Card, CardContent } from "@material-ui/core";
 import React, { useEffect, useState } from "react";
 import {
   HarmonyFormsAccessors,
@@ -26,32 +26,34 @@ export const HarmonyCourseCheckboxes = ({ course }: HarmonyCourseCheckboxesProps
   }, [course, profList, roomList, setClass, timeList]);
 
   return (
-    <Box component="div" m={2}>
-      <Paper>
-        <b>{course}</b>
-        <HarmonyCheckboxList
-          course={course}
-          customLabel={(profObj: SingularAccessors["professor"]) => {
-            return `${profObj.First} ${profObj.Last}`;
-          }}
-          id="professors"
-          list={professors as HarmonyFormsAccessors["professors"]}
-          setList={setProfList}
-        />
-        <HarmonyCheckboxList
-          course={course}
-          id="times"
-          list={times as HarmonyFormsAccessors["times"]}
-          setList={setTimeList}
-        />
-        <HarmonyCheckboxList
-          course={course}
-          id="rooms"
-          list={rooms as HarmonyFormsAccessors["rooms"]}
-          setList={setRoomList}
-        />
-      </Paper>
-    </Box>
+    <Card style={{ marginBottom: "2em" }} variant="outlined">
+      <CardContent>
+        <h2>{course}</h2>
+        <div style={{ display: "flex", justifyContent: "space-around" }}>
+          <HarmonyCheckboxList
+            course={course}
+            customLabel={(profObj: SingularAccessors["professor"]) => {
+              return `${profObj.First} ${profObj.Last}`;
+            }}
+            id="professors"
+            list={professors as HarmonyFormsAccessors["professors"]}
+            setList={setProfList}
+          />
+          <HarmonyCheckboxList
+            course={course}
+            id="times"
+            list={times as HarmonyFormsAccessors["times"]}
+            setList={setTimeList}
+          />
+          <HarmonyCheckboxList
+            course={course}
+            id="rooms"
+            list={rooms as HarmonyFormsAccessors["rooms"]}
+            setList={setRoomList}
+          />
+        </div>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCourseCheckboxes.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyCourseCheckboxes.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent } from "@material-ui/core";
+import { Box, Card, CardContent, Grid } from "@material-ui/core";
 import React, { useEffect, useState } from "react";
 import {
   HarmonyFormsAccessors,
@@ -26,34 +26,36 @@ export const HarmonyCourseCheckboxes = ({ course }: HarmonyCourseCheckboxesProps
   }, [course, profList, roomList, setClass, timeList]);
 
   return (
-    <Card style={{ marginBottom: "2em" }} variant="outlined">
-      <CardContent>
-        <h2>{course}</h2>
-        <div style={{ display: "flex", justifyContent: "space-around" }}>
-          <HarmonyCheckboxList
-            course={course}
-            customLabel={(profObj: SingularAccessors["professor"]) => {
-              return `${profObj.First} ${profObj.Last}`;
-            }}
-            id="professors"
-            list={professors as HarmonyFormsAccessors["professors"]}
-            setList={setProfList}
-          />
-          <HarmonyCheckboxList
-            course={course}
-            id="times"
-            list={times as HarmonyFormsAccessors["times"]}
-            setList={setTimeList}
-          />
-          <HarmonyCheckboxList
-            course={course}
-            id="rooms"
-            list={rooms as HarmonyFormsAccessors["rooms"]}
-            setList={setRoomList}
-          />
-        </div>
-      </CardContent>
-    </Card>
+    <Box mb={2}>
+      <Card variant="outlined">
+        <CardContent>
+          <h2>{course}</h2>
+          <Grid container justify="space-around">
+            <HarmonyCheckboxList
+              course={course}
+              customLabel={(profObj: SingularAccessors["professor"]) => {
+                return `${profObj.First} ${profObj.Last}`;
+              }}
+              id="professors"
+              list={professors as HarmonyFormsAccessors["professors"]}
+              setList={setProfList}
+            />
+            <HarmonyCheckboxList
+              course={course}
+              id="times"
+              list={times as HarmonyFormsAccessors["times"]}
+              setList={setTimeList}
+            />
+            <HarmonyCheckboxList
+              course={course}
+              id="rooms"
+              list={rooms as HarmonyFormsAccessors["rooms"]}
+              setList={setRoomList}
+            />
+          </Grid>
+        </CardContent>
+      </Card>
+    </Box>
   );
 };
 

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonySchedule.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonySchedule.tsx
@@ -1,37 +1,20 @@
-import { Button } from "@material-ui/core";
 import { Schedule } from "components";
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import { getEvents, getProfs } from "utilities";
-import {
-  HarmonyResultState,
-  useAppContext,
-  useHarmonyResultStore,
-  useRedirect,
-} from "utilities/hooks";
+import { HarmonyResultState, useHarmonyResultStore } from "utilities/hooks";
 
 /** Display the resulting schedule from Harmony on a
  *   visual schedule.
  */
 export const HarmonySchedule = () => {
   const schedule = useHarmonyResultStore(selector);
-  const { appDispatch } = useAppContext();
-  const redirectTo = useRedirect();
 
   const { headers, events } = useMemo(() => {
     return { events: getEvents(schedule, "faculty"), headers: getProfs(schedule) };
   }, [schedule]);
 
-  const onClick = useCallback(() => {
-    appDispatch({ payload: { schedule }, type: "setScheduleData" });
-    redirectTo("/");
-  }, [appDispatch, redirectTo, schedule]);
-
   return (
     <>
-      <br />
-      <Button onClick={onClick} type="button">
-        Send to Schedulizer
-      </Button>
       <Schedule calendarHeaders={headers} groupedEvents={events} readonly scheduleType="harmony" />
     </>
   );

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
@@ -8,7 +8,7 @@ import {
 import React, { useEffect } from "react";
 
 const getSteps = () => {
-  return ["Welcome", "Import Data", "Create Assignments", "Find Schedule"];
+  return ["Welcome", "Import Data", "Update Data", "Create Assignments", "Find Schedule"];
 };
 
 // TODO: somehow this should be linked to the values in getSteps
@@ -17,10 +17,12 @@ const getStepContent = (step: number) => {
     case 0:
       return <HarmonyStepperWelcome />;
     case 1:
-      return <HarmonyStepperImportData />;
+      return <>Use inferred data from schedule. and set assignments. Optional</>;
     case 2:
-      return <HarmonyStepperAssignments />;
+      return <HarmonyStepperImportData />;
     case 3:
+      return <HarmonyStepperAssignments />;
+    case 4:
       return <HarmonyStepperResult />;
     default:
       return <>Unknown step</>;
@@ -104,7 +106,7 @@ export const HarmonyStepper = () => {
             <div className="harmony-stepper-content" style={{ flex: "1 0 auto" }}>
               {getStepContent(activeStep)}
             </div>
-            <div style={{ flex: "0 1 auto" }}>
+            <div style={{ flex: "0 1 auto", textAlign: "end" }}>
               <Button
                 className="harmony-stepper-button"
                 disabled={activeStep === 0}
@@ -132,7 +134,7 @@ export const HarmonyStepper = () => {
       <Stepper
         activeStep={activeStep}
         alternativeLabel
-        style={{ flex: "0 1 auto", paddingTop: "5em" }}
+        style={{ flex: "0 1 auto", paddingTop: "5em", textAlign: "center" }}
       >
         {steps.map((label, index) => {
           const stepProps: { completed?: boolean } = {};

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
@@ -3,6 +3,7 @@ import {
   HarmonyStepperAssignments,
   HarmonyStepperImportData,
   HarmonyStepperResult,
+  HarmonyStepperUpdateData,
   HarmonyStepperWelcome,
 } from "components";
 import React, { useEffect } from "react";
@@ -17,9 +18,9 @@ const getStepContent = (step: number) => {
     case 0:
       return <HarmonyStepperWelcome />;
     case 1:
-      return <>Use inferred data from schedule. and set assignments. Optional</>;
-    case 2:
       return <HarmonyStepperImportData />;
+    case 2:
+      return <HarmonyStepperUpdateData />;
     case 3:
       return <HarmonyStepperAssignments />;
     case 4:

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
@@ -1,6 +1,6 @@
 import { Button, Step, StepLabel, Stepper, Typography } from "@material-ui/core";
 import {
-  HarmonyAddAssignments,
+  HarmonyStepperAssignments,
   HarmonyStepperImportData,
   HarmonyStepperResult,
   HarmonyStepperWelcome,
@@ -19,7 +19,7 @@ const getStepContent = (step: number) => {
     case 1:
       return <HarmonyStepperImportData />;
     case 2:
-      return <HarmonyAddAssignments />;
+      return <HarmonyStepperAssignments />;
     case 3:
       return <HarmonyStepperResult />;
     default:

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
@@ -6,7 +6,17 @@ import {
   HarmonyStepperUpdateData,
   HarmonyStepperWelcome,
 } from "components";
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
+import {
+  HarmonyResultState,
+  useAppContext,
+  useHarmonyResultStore,
+  useRedirect,
+} from "utilities/hooks";
+
+const selector = ({ schedule }: HarmonyResultState) => {
+  return schedule;
+};
 
 const getSteps = () => {
   return ["Welcome", "Import Data", "Update Data", "Create Assignments", "Find Schedule"];
@@ -36,6 +46,9 @@ export const HarmonyStepper = () => {
   const [activeStep, setActiveStep] = React.useState(0);
   const [skipped, setSkipped] = React.useState(new Set<number>());
   const steps = getSteps();
+  const { appDispatch } = useAppContext();
+  const redirectTo = useRedirect();
+  const schedule = useHarmonyResultStore(selector);
 
   const isStepOptional = (step: number) => {
     return step === 1;
@@ -90,6 +103,11 @@ export const HarmonyStepper = () => {
     window.scrollTo(0, 0);
   }, [activeStep]);
 
+  const onClick = useCallback(() => {
+    appDispatch({ payload: { schedule }, type: "setScheduleData" });
+    redirectTo("/");
+  }, [appDispatch, redirectTo, schedule]);
+
   return (
     <div className="harmony-stepper-root">
       <div style={{ flex: "1 0 auto" }}>
@@ -100,6 +118,16 @@ export const HarmonyStepper = () => {
             </Typography>
             <Button className="harmony-stepper-button" onClick={handleReset}>
               Reset
+            </Button>
+            <Button
+              className="harmony-stepper-button"
+              disabled={activeStep === 0}
+              onClick={handleBack}
+            >
+              Back
+            </Button>
+            <Button onClick={onClick} type="button">
+              Send to Schedulizer
             </Button>
           </div>
         ) : (

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepper.tsx
@@ -1,0 +1,155 @@
+import { Button, Step, StepLabel, Stepper, Typography } from "@material-ui/core";
+import {
+  HarmonyAddAssignments,
+  HarmonyStepperImportData,
+  HarmonyStepperResult,
+  HarmonyStepperWelcome,
+} from "components";
+import React, { useEffect } from "react";
+
+const getSteps = () => {
+  return ["Welcome", "Import Data", "Create Assignments", "Find Schedule"];
+};
+
+// TODO: somehow this should be linked to the values in getSteps
+const getStepContent = (step: number) => {
+  switch (step) {
+    case 0:
+      return <HarmonyStepperWelcome />;
+    case 1:
+      return <HarmonyStepperImportData />;
+    case 2:
+      return <HarmonyAddAssignments />;
+    case 3:
+      return <HarmonyStepperResult />;
+    default:
+      return <>Unknown step</>;
+  }
+};
+
+// TODO: remove inline styles
+// https://material-ui.com/components/steppers/
+export const HarmonyStepper = () => {
+  const [activeStep, setActiveStep] = React.useState(0);
+  const [skipped, setSkipped] = React.useState(new Set<number>());
+  const steps = getSteps();
+
+  const isStepOptional = (step: number) => {
+    return step === 1;
+  };
+
+  const isStepSkipped = (step: number) => {
+    return skipped.has(step);
+  };
+
+  const handleNext = () => {
+    let newSkipped = skipped;
+    if (isStepSkipped(activeStep)) {
+      newSkipped = new Set(newSkipped.values());
+      newSkipped.delete(activeStep);
+    }
+
+    setActiveStep((prevActiveStep) => {
+      return prevActiveStep + 1;
+    });
+    setSkipped(newSkipped);
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => {
+      return prevActiveStep - 1;
+    });
+  };
+
+  const handleSkip = () => {
+    if (!isStepOptional(activeStep)) {
+      // You probably want to guard against something like this,
+      // it should never occur unless someone's actively trying to break something.
+      throw new Error("You can't skip a step that isn't optional.");
+    }
+
+    setActiveStep((prevActiveStep) => {
+      return prevActiveStep + 1;
+    });
+    setSkipped((prevSkipped) => {
+      const newSkipped = new Set(prevSkipped.values());
+      newSkipped.add(activeStep);
+      return newSkipped;
+    });
+  };
+
+  const handleReset = () => {
+    setActiveStep(0);
+  };
+
+  // Scroll to top when step changes.
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [activeStep]);
+
+  return (
+    <div className="harmony-stepper-root">
+      <div style={{ flex: "1 0 auto" }}>
+        {activeStep === steps.length ? (
+          <div>
+            <Typography className="harmony-stepper-content">
+              All steps completed - you&apos;re finished
+            </Typography>
+            <Button className="harmony-stepper-button" onClick={handleReset}>
+              Reset
+            </Button>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+            <div className="harmony-stepper-content" style={{ flex: "1 0 auto" }}>
+              {getStepContent(activeStep)}
+            </div>
+            <div style={{ flex: "0 1 auto" }}>
+              <Button
+                className="harmony-stepper-button"
+                disabled={activeStep === 0}
+                onClick={handleBack}
+              >
+                Back
+              </Button>
+              {isStepOptional(activeStep) && (
+                <Button
+                  className="harmony-stepper-button"
+                  color="secondary"
+                  onClick={handleSkip}
+                  variant="contained"
+                >
+                  Skip
+                </Button>
+              )}
+              <Button color="primary" onClick={handleNext} variant="contained">
+                {activeStep === steps.length - 1 ? "Finish" : "Next"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+      <Stepper
+        activeStep={activeStep}
+        alternativeLabel
+        style={{ flex: "0 1 auto", paddingTop: "5em" }}
+      >
+        {steps.map((label, index) => {
+          const stepProps: { completed?: boolean } = {};
+          const labelProps: { optional?: React.ReactNode } = {};
+          if (isStepOptional(index)) {
+            labelProps.optional = <Typography variant="caption">Optional</Typography>;
+          }
+          if (isStepSkipped(index)) {
+            stepProps.completed = false;
+          }
+          return (
+            <Step key={label} {...stepProps}>
+              <StepLabel {...labelProps}>{label}</StepLabel>
+            </Step>
+          );
+        })}
+      </Stepper>
+    </div>
+  );
+};

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperAssignments.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperAssignments.tsx
@@ -1,0 +1,12 @@
+import { HarmonyAddAssignments } from "components";
+import { AnimateShowAndHide } from "components/reuseables";
+import React from "react";
+
+export const HarmonyStepperAssignments = () => {
+  return (
+    <>
+      <AnimateShowAndHide>Add Assignments</AnimateShowAndHide>
+      <HarmonyAddAssignments />
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperAssignments.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperAssignments.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export const HarmonyStepperAssignments = () => {
   return (
     <>
-      <AnimateShowAndHide>Add Assignments</AnimateShowAndHide>
+      <AnimateShowAndHide>Assignments</AnimateShowAndHide>
       <HarmonyAddAssignments />
     </>
   );

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperImportData.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperImportData.tsx
@@ -1,15 +1,11 @@
-import { HarmonyFieldArrayForm } from "components";
 import { AnimateShowAndHide } from "components/reuseables";
 import React from "react";
 
 export const HarmonyStepperImportData = () => {
   return (
     <>
-      <AnimateShowAndHide>Update Data</AnimateShowAndHide>
-      <HarmonyFieldArrayForm defaultValue={{ First: "", Last: "" }} fieldsName="professors" />
-      <HarmonyFieldArrayForm defaultValue={{ Course: "" }} fieldsName="courses" />
-      <HarmonyFieldArrayForm defaultValue={{ Room: "" }} fieldsName="rooms" />
-      <HarmonyFieldArrayForm defaultValue={{ Time: "" }} fieldsName="times" />
+      <AnimateShowAndHide>Import Data</AnimateShowAndHide>
+      Use inferred data from schedule. and set assignments. Optional
     </>
   );
 };

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperImportData.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperImportData.tsx
@@ -1,0 +1,15 @@
+import { HarmonyFieldArrayForm } from "components";
+import { AnimateShowAndHide } from "components/reuseables";
+import React from "react";
+
+export const HarmonyStepperImportData = () => {
+  return (
+    <>
+      <AnimateShowAndHide>Import Data</AnimateShowAndHide>
+      <HarmonyFieldArrayForm defaultValue={{ First: "", Last: "" }} fieldsName="professors" />
+      <HarmonyFieldArrayForm defaultValue={{ Course: "" }} fieldsName="courses" />
+      <HarmonyFieldArrayForm defaultValue={{ Room: "" }} fieldsName="rooms" />
+      <HarmonyFieldArrayForm defaultValue={{ Time: "" }} fieldsName="times" />
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperImportData.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperImportData.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export const HarmonyStepperImportData = () => {
   return (
     <>
-      <AnimateShowAndHide>Import Data</AnimateShowAndHide>
+      <AnimateShowAndHide>Update Data</AnimateShowAndHide>
       <HarmonyFieldArrayForm defaultValue={{ First: "", Last: "" }} fieldsName="professors" />
       <HarmonyFieldArrayForm defaultValue={{ Course: "" }} fieldsName="courses" />
       <HarmonyFieldArrayForm defaultValue={{ Room: "" }} fieldsName="rooms" />

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperResult.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperResult.tsx
@@ -1,9 +1,10 @@
-import { Harmony, HarmonySchedule } from "components";
+import { AnimateShowAndHide, Harmony, HarmonySchedule } from "components";
 import React from "react";
 
 export const HarmonyStepperResult = () => {
   return (
     <>
+      <AnimateShowAndHide>Results</AnimateShowAndHide>
       <Harmony />
       <HarmonySchedule />
     </>

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperResult.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperResult.tsx
@@ -1,0 +1,11 @@
+import { Harmony, HarmonySchedule } from "components";
+import React from "react";
+
+export const HarmonyStepperResult = () => {
+  return (
+    <>
+      <Harmony />
+      <HarmonySchedule />
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperUpdateData.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperUpdateData.tsx
@@ -1,0 +1,15 @@
+import { HarmonyFieldArrayForm } from "components";
+import { AnimateShowAndHide } from "components/reuseables";
+import React from "react";
+
+export const HarmonyStepperUpdateData = () => {
+  return (
+    <>
+      <AnimateShowAndHide>Update Data</AnimateShowAndHide>
+      <HarmonyFieldArrayForm defaultValue={{ First: "", Last: "" }} fieldsName="professors" />
+      <HarmonyFieldArrayForm defaultValue={{ Course: "" }} fieldsName="courses" />
+      <HarmonyFieldArrayForm defaultValue={{ Room: "" }} fieldsName="rooms" />
+      <HarmonyFieldArrayForm defaultValue={{ Time: "" }} fieldsName="times" />
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperUpdateData.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperUpdateData.tsx
@@ -9,7 +9,11 @@ export const HarmonyStepperUpdateData = () => {
       <HarmonyFieldArrayForm defaultValue={{ First: "", Last: "" }} fieldsName="professors" />
       <HarmonyFieldArrayForm defaultValue={{ Course: "" }} fieldsName="courses" />
       <HarmonyFieldArrayForm defaultValue={{ Room: "" }} fieldsName="rooms" />
-      <HarmonyFieldArrayForm defaultValue={{ Time: "" }} fieldsName="times" />
+      <HarmonyFieldArrayForm
+        defaultValue={{ Time: "" }}
+        fieldsName="times"
+        textFieldProps={{ type: "time" }}
+      />
     </>
   );
 };

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperWelcome.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/HarmonyStepperWelcome.tsx
@@ -1,0 +1,13 @@
+import { AnimateShowAndHide } from "components";
+import React from "react";
+
+export const HarmonyStepperWelcome = () => {
+  return (
+    <>
+      <AnimateShowAndHide>Harmony</AnimateShowAndHide>
+      <h1>
+        Note: This page is in a <i>pre-alpha</i> state. Output might not be perfect.
+      </h1>
+    </>
+  );
+};

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/index.ts
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/index.ts
@@ -1,0 +1,4 @@
+export * from "./HarmonyStepper";
+export * from "./HarmonyStepperImportData";
+export * from "./HarmonyStepperResult";
+export * from "./HarmonyStepperWelcome";

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/index.ts
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/index.ts
@@ -1,4 +1,5 @@
 export * from "./HarmonyStepper";
+export * from "./HarmonyStepperAssignments";
 export * from "./HarmonyStepperImportData";
 export * from "./HarmonyStepperResult";
 export * from "./HarmonyStepperWelcome";

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/index.ts
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/HarmonyStepper/index.ts
@@ -2,4 +2,5 @@ export * from "./HarmonyStepper";
 export * from "./HarmonyStepperAssignments";
 export * from "./HarmonyStepperImportData";
 export * from "./HarmonyStepperResult";
+export * from "./HarmonyStepperUpdateData";
 export * from "./HarmonyStepperWelcome";

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/index.ts
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/Harmony/index.ts
@@ -5,3 +5,4 @@ export * from "./HarmonyCheckboxList";
 export * from "./HarmonyCourseCheckboxes";
 export * from "./HarmonyFieldArrayForm";
 export * from "./HarmonySchedule";
+export * from "./HarmonyStepper";

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/HarmonyPage.scss
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/HarmonyPage.scss
@@ -1,0 +1,16 @@
+.harmony-stepper-root {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.harmony-stepper-button {
+  margin-right: 1em !important;
+}
+
+.harmony-stepper-content {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  height: 100%;
+}

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/HarmonyPage.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/HarmonyPage.tsx
@@ -1,7 +1,6 @@
-import { AnimateShowAndHide, HarmonyFieldArrayForm } from "components";
+import { HarmonyStepper } from "components";
 import React from "react";
-import { Harmony, HarmonyAddAssignments } from "./Harmony";
-import { HarmonySchedule } from "./Harmony/HarmonySchedule";
+import "./HarmonyPage.scss";
 
 /**
  * The page contains all of the Harmoniously user-experience.
@@ -11,19 +10,5 @@ import { HarmonySchedule } from "./Harmony/HarmonySchedule";
  *   to the Schedulizer to make edits.
  */
 export const HarmonyPage = () => {
-  return (
-    <>
-      <AnimateShowAndHide>Harmony</AnimateShowAndHide>
-      <h1>
-        Note: This page is in a <i>pre-alpha</i> state. Output might not be perfect.
-      </h1>
-      <HarmonyFieldArrayForm defaultValue={{ First: "", Last: "" }} fieldsName="professors" />
-      <HarmonyFieldArrayForm defaultValue={{ Course: "" }} fieldsName="courses" />
-      <HarmonyFieldArrayForm defaultValue={{ Room: "" }} fieldsName="rooms" />
-      <HarmonyFieldArrayForm defaultValue={{ Time: "" }} fieldsName="times" />
-      <HarmonyAddAssignments />
-      <Harmony />
-      <HarmonySchedule />
-    </>
-  );
+  return <HarmonyStepper />;
 };

--- a/client-course-schedulizer/src/components/pages/HarmonyPage/HarmonyPage.tsx
+++ b/client-course-schedulizer/src/components/pages/HarmonyPage/HarmonyPage.tsx
@@ -1,4 +1,4 @@
-import { HarmonyStepper } from "components";
+import { HarmonyStepper, Page } from "components";
 import React from "react";
 import "./HarmonyPage.scss";
 
@@ -10,5 +10,9 @@ import "./HarmonyPage.scss";
  *   to the Schedulizer to make edits.
  */
 export const HarmonyPage = () => {
-  return <HarmonyStepper />;
+  return (
+    <Page>
+      <HarmonyStepper />
+    </Page>
+  );
 };

--- a/client-course-schedulizer/src/components/reuseables/FieldArrayForm/DeleteFieldButton/DeleteFieldButton.scss
+++ b/client-course-schedulizer/src/components/reuseables/FieldArrayForm/DeleteFieldButton/DeleteFieldButton.scss
@@ -1,0 +1,4 @@
+div.delete-field-button {
+  display: flex;
+  align-items: center;
+}

--- a/client-course-schedulizer/src/components/reuseables/FieldArrayForm/DeleteFieldButton/DeleteFieldButton.tsx
+++ b/client-course-schedulizer/src/components/reuseables/FieldArrayForm/DeleteFieldButton/DeleteFieldButton.tsx
@@ -2,6 +2,7 @@ import { IconButton, Tooltip } from "@material-ui/core";
 import HighlightOffIcon from "@material-ui/icons/HighlightOff";
 import React from "react";
 import { useFieldArrayFormContext } from "utilities";
+import "./DeleteFieldButton.scss";
 
 interface DeleteFieldButtonProps {
   index: number;
@@ -14,7 +15,7 @@ export const DeleteFieldButton = ({ index }: DeleteFieldButtonProps) => {
   const { remove } = useFieldArrayFormContext();
 
   return (
-    <div>
+    <div className="delete-field-button">
       <Tooltip title="Remove">
         <IconButton
           aria-label="remove"

--- a/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayField/FieldArrayField.tsx
+++ b/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayField/FieldArrayField.tsx
@@ -13,12 +13,17 @@ interface FieldArrayFieldProps {
  *   or just one.
  */
 export const FieldArrayField = ({ index, fieldIndex }: FieldArrayFieldProps) => {
-  const { control, titleCaseName: name, defaultValue = {} } = useFieldArrayFormContext();
+  const {
+    control,
+    titleCaseName: name,
+    defaultValue = {},
+    textFieldProps,
+  } = useFieldArrayFormContext();
 
   return (
     <Box m={1}>
       <Controller
-        as={<TextField label={fieldIndex} variant="outlined" />}
+        as={<TextField {...textFieldProps} label={fieldIndex} variant="outlined" />}
         control={control}
         defaultValue={defaultValue[fieldIndex]}
         name={`${name}[${index}][${fieldIndex}]`}

--- a/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayFields/FieldArrayFields.tsx
+++ b/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayFields/FieldArrayFields.tsx
@@ -15,7 +15,8 @@ export const FieldArrayFields = () => {
     <>
       {fields.map((field, index) => {
         return (
-          <Grid key={field.id} container justify="center">
+          <Grid key={field.id} container>
+            <DeleteFieldButton index={index} />
             {Object.keys(field)
               .filter((f) => {
                 return f !== "id";
@@ -23,7 +24,6 @@ export const FieldArrayFields = () => {
               .map((key) => {
                 return <FieldArrayField key={key} fieldIndex={key} index={index} />;
               })}
-            <DeleteFieldButton index={index} />
           </Grid>
         );
       })}

--- a/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayForm.tsx
+++ b/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayForm.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent } from "@material-ui/core";
+import { Card, CardContent, TextFieldProps } from "@material-ui/core";
 import startCase from "lodash/startCase";
 import toLower from "lodash/toLower";
 import React from "react";
@@ -11,6 +11,7 @@ export interface FieldArrayFormProps {
   defaultValue: object;
   fieldsName: string;
   onSubmit?: (data: object[]) => void;
+  textFieldProps?: TextFieldProps;
 }
 
 /**
@@ -18,7 +19,12 @@ export interface FieldArrayFormProps {
  * This uses a provider to pass form related data down the component tree.
  * Handles the form submission and formats the name to look nice on the web.
  */
-export const FieldArrayForm = ({ fieldsName, defaultValue, onSubmit }: FieldArrayFormProps) => {
+export const FieldArrayForm = ({
+  fieldsName,
+  defaultValue,
+  onSubmit,
+  textFieldProps,
+}: FieldArrayFormProps) => {
   const titleCaseName = startCase(toLower(fieldsName));
   const formMethods = useForm({
     defaultValues: { [titleCaseName]: [defaultValue] },
@@ -34,6 +40,7 @@ export const FieldArrayForm = ({ fieldsName, defaultValue, onSubmit }: FieldArra
       {...formMethods}
       {...fieldArrayMethods}
       defaultValue={defaultValue}
+      textFieldProps={textFieldProps}
       titleCaseName={titleCaseName}
     >
       <Card style={{ marginBottom: "2em" }} variant="outlined">

--- a/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayForm.tsx
+++ b/client-course-schedulizer/src/components/reuseables/FieldArrayForm/FieldArrayForm.tsx
@@ -1,3 +1,4 @@
+import { Card, CardContent } from "@material-ui/core";
 import startCase from "lodash/startCase";
 import toLower from "lodash/toLower";
 import React from "react";
@@ -35,15 +36,19 @@ export const FieldArrayForm = ({ fieldsName, defaultValue, onSubmit }: FieldArra
       defaultValue={defaultValue}
       titleCaseName={titleCaseName}
     >
-      <form
-        onSubmit={handleSubmit((data) => {
-          onSubmit && onSubmit(data[titleCaseName] as object[]);
-        })}
-      >
-        <h3>{titleCaseName}: </h3>
-        <FieldArrayFields />
-        <FieldArrayFormActionButtons />
-      </form>
+      <Card style={{ marginBottom: "2em" }} variant="outlined">
+        <CardContent>
+          <form
+            onSubmit={handleSubmit((data) => {
+              onSubmit && onSubmit(data[titleCaseName] as object[]);
+            })}
+          >
+            <h2>{titleCaseName}: </h2>
+            <FieldArrayFields />
+            <FieldArrayFormActionButtons />
+          </form>
+        </CardContent>
+      </Card>
     </FieldArrayFormProvider>
   );
 };

--- a/client-course-schedulizer/src/components/reuseables/Page/Page.scss
+++ b/client-course-schedulizer/src/components/reuseables/Page/Page.scss
@@ -1,0 +1,12 @@
+div.Page {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  padding: 1em;
+}
+
+div.Page > div.content {
+  max-width: 900px;
+  text-align: left;
+  width: 900px;
+}

--- a/client-course-schedulizer/src/components/reuseables/Page/Page.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Page/Page.tsx
@@ -3,7 +3,7 @@ import React, { PropsWithChildren } from "react";
 export const Page = ({ children }: PropsWithChildren<{}>) => {
   return (
     <div style={{ display: "flex", height: "100%", justifyContent: "center", padding: "1em" }}>
-      <div style={{ maxWidth: 900, textAlign: "left" }}>{children}</div>
+      <div style={{ maxWidth: 900, textAlign: "left", width: 900 }}>{children}</div>
     </div>
   );
 };

--- a/client-course-schedulizer/src/components/reuseables/Page/Page.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Page/Page.tsx
@@ -1,0 +1,9 @@
+import React, { PropsWithChildren } from "react";
+
+export const Page = ({ children }: PropsWithChildren<{}>) => {
+  return (
+    <div style={{ display: "flex", height: "100%", justifyContent: "center", padding: "1em" }}>
+      <div style={{ maxWidth: 900, textAlign: "left" }}>{children}</div>
+    </div>
+  );
+};

--- a/client-course-schedulizer/src/components/reuseables/Page/Page.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Page/Page.tsx
@@ -1,9 +1,10 @@
 import React, { PropsWithChildren } from "react";
+import "./Page.scss";
 
 export const Page = ({ children }: PropsWithChildren<{}>) => {
   return (
-    <div style={{ display: "flex", height: "100%", justifyContent: "center", padding: "1em" }}>
-      <div style={{ maxWidth: 900, textAlign: "left", width: 900 }}>{children}</div>
+    <div className="Page">
+      <div className="content">{children}</div>
     </div>
   );
 };

--- a/client-course-schedulizer/src/components/reuseables/Page/index.ts
+++ b/client-course-schedulizer/src/components/reuseables/Page/index.ts
@@ -1,0 +1,1 @@
+export * from "./Page";

--- a/client-course-schedulizer/src/components/reuseables/animated/AnimateShowAndHide/AnimateShowAndHide.scss
+++ b/client-course-schedulizer/src/components/reuseables/animated/AnimateShowAndHide/AnimateShowAndHide.scss
@@ -11,7 +11,6 @@
 
 .show-and-hide-text {
   position: relative;
-  height: 110px;
   line-height: 110px;
   color: black;
   font-size: 8em;
@@ -23,5 +22,4 @@
 
 .show-and-hide-text > div {
   overflow: hidden;
-  padding-right: 2em;
 }

--- a/client-course-schedulizer/src/components/reuseables/animated/AnimateShowAndHide/AnimateShowAndHide.tsx
+++ b/client-course-schedulizer/src/components/reuseables/animated/AnimateShowAndHide/AnimateShowAndHide.tsx
@@ -1,4 +1,3 @@
-import { Grid } from "@material-ui/core";
 import React, { PropsWithChildren, useCallback, useState } from "react";
 import { animated, useSpring } from "react-spring";
 import ReactVisibilitySensor from "react-visibility-sensor";
@@ -21,7 +20,7 @@ export const AnimateShowAndHide = ({ children, once }: PropsWithChildren<Animate
   const springProps = useSpring({
     config: { friction: 200, mass: 5, tension: 2000 },
     from: { height: 0, opacity: 0, x: 20 },
-    height: isVisible ? 110 : 0,
+    height: isVisible ? 130 : 0,
     opacity: isVisible ? 1 : 0,
     x: isVisible ? 0 : 20,
   });
@@ -44,11 +43,11 @@ export const AnimateShowAndHide = ({ children, once }: PropsWithChildren<Animate
 
   return (
     <ReactVisibilitySensor active={isActive} onChange={onVisibilityChange}>
-      <Grid className="show-and-hide-main" container justify="flex-start">
+      <div className="show-and-hide-main">
         <animated.div className="show-and-hide-text" style={springProps}>
           <animated.div style={{ height }}>{children}</animated.div>
         </animated.div>
-      </Grid>
+      </div>
     </ReactVisibilitySensor>
   );
 };

--- a/client-course-schedulizer/src/components/reuseables/animated/AnimateShowAndHide/AnimateShowAndHide.tsx
+++ b/client-course-schedulizer/src/components/reuseables/animated/AnimateShowAndHide/AnimateShowAndHide.tsx
@@ -45,7 +45,7 @@ export const AnimateShowAndHide = ({ children, once }: PropsWithChildren<Animate
     <ReactVisibilitySensor active={isActive} onChange={onVisibilityChange}>
       <div className="show-and-hide-main">
         <animated.div className="show-and-hide-text" style={springProps}>
-          <animated.div style={{ height }}>{children}</animated.div>
+          <animated.div style={{ height, paddingRight: 20 }}>{children}</animated.div>
         </animated.div>
       </div>
     </ReactVisibilitySensor>

--- a/client-course-schedulizer/src/components/reuseables/index.ts
+++ b/client-course-schedulizer/src/components/reuseables/index.ts
@@ -9,5 +9,6 @@ export * from "./GridItem";
 export * from "./ImportInputWrapper";
 export * from "./ModalPagination";
 export * from "./NewTabLink";
+export * from "./Page";
 export * from "./PopoverButton";
 export * from "./Schedule";

--- a/client-course-schedulizer/src/utilities/hooks/useHarmonyAssignmentsStore.ts
+++ b/client-course-schedulizer/src/utilities/hooks/useHarmonyAssignmentsStore.ts
@@ -1,28 +1,22 @@
 import { Assignments, ClassLimits } from "@harmoniously/react";
 import { immer } from "utilities";
 import create, { State } from "zustand";
-import { persist } from "zustand/middleware";
 
 /**
  * A hook to get access to a global store containing assignment data for Harmony
  * Persists the value in localStorage
  */
 export const useHarmonyAssignmentsStore = create<HarmonyAssignmentsState>(
-  persist(
-    immer<HarmonyAssignmentsState>((set) => {
-      return {
-        assignments: {},
-        setClass: (className: string, attributes: ClassLimits) => {
-          return set((state) => {
-            state.assignments[className] = attributes;
-          });
-        },
-      };
-    }),
-    {
-      name: "harmonyAssignmentsState",
-    },
-  ),
+  immer<HarmonyAssignmentsState>((set) => {
+    return {
+      assignments: {},
+      setClass: (className: string, attributes: ClassLimits) => {
+        return set((state) => {
+          state.assignments[className] = attributes;
+        });
+      },
+    };
+  }),
 );
 
 export interface HarmonyAssignmentsState extends State {

--- a/client-course-schedulizer/src/utilities/hooks/useHarmonyFormsStore.ts
+++ b/client-course-schedulizer/src/utilities/hooks/useHarmonyFormsStore.ts
@@ -1,5 +1,4 @@
 import create, { GetState, SetState, State } from "zustand";
-import { persist } from "zustand/middleware";
 
 /**
  * A hook to get access to a global store storing all values related to the
@@ -9,24 +8,19 @@ import { persist } from "zustand/middleware";
  * ref: https://dev.to/karanpratapsingh/simplify-your-store-a-brief-introduction-to-zustand-250h
  */
 export const useHarmonyFormsStore = create<HarmonyFormsState>(
-  persist<HarmonyFormsState>(
-    (set: SetState<HarmonyFormsState>, get: GetState<HarmonyFormsState>) => {
-      return {
-        courses: [],
-        professors: [],
-        rooms: [],
-        times: [],
-        update: (key: string, data: string[]) => {
-          return set(() => {
-            return { [key as keyof HarmonyFormsAccessors]: data };
-          });
-        },
-      };
-    },
-    {
-      name: "harmonyFormsState",
-    },
-  ),
+  (set: SetState<HarmonyFormsState>, get: GetState<HarmonyFormsState>) => {
+    return {
+      courses: [],
+      professors: [],
+      rooms: [],
+      times: [],
+      update: (key: string, data: string[]) => {
+        return set(() => {
+          return { [key as keyof HarmonyFormsAccessors]: data };
+        });
+      },
+    };
+  },
 );
 
 /** Adds functions to accessors */

--- a/client-course-schedulizer/src/utilities/hooks/useHarmonyResultStore.ts
+++ b/client-course-schedulizer/src/utilities/hooks/useHarmonyResultStore.ts
@@ -1,23 +1,17 @@
 import { Result } from "@harmoniously/react";
 import { Day, Schedule, SemesterLength, Term } from "utilities/interfaces";
 import create, { GetState, SetState, State } from "zustand";
-import { persist } from "zustand/middleware";
 
 export const useHarmonyResultStore = create<HarmonyResultState>(
-  persist<HarmonyResultState>(
-    (set: SetState<HarmonyResultState>, get: GetState<HarmonyResultState>) => {
-      return {
-        result: {},
-        schedule: { courses: [] },
-        setResult: (res: Result) => {
-          set({ result: res, schedule: convertToSchedule(res) });
-        },
-      };
-    },
-    {
-      name: "harmonyResultState",
-    },
-  ),
+  (set: SetState<HarmonyResultState>, get: GetState<HarmonyResultState>) => {
+    return {
+      result: {},
+      schedule: { courses: [] },
+      setResult: (res: Result) => {
+        set({ result: res, schedule: convertToSchedule(res) });
+      },
+    };
+  },
 );
 
 export interface HarmonyResultState extends State {

--- a/client-course-schedulizer/src/utilities/interfaces/fieldArrayTypes.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/fieldArrayTypes.ts
@@ -1,3 +1,4 @@
+import { TextFieldProps } from "@material-ui/core/TextField/TextField";
 import { FieldValues, UseFieldArrayMethods, UseFormMethods } from "react-hook-form";
 
 /**
@@ -5,6 +6,7 @@ import { FieldValues, UseFieldArrayMethods, UseFormMethods } from "react-hook-fo
  */
 interface FieldArrayHelpers {
   defaultValue: Partial<FieldValues>;
+  textFieldProps: TextFieldProps;
   titleCaseName: string;
 }
 


### PR DESCRIPTION
In this PR

- adds the `<footer>` tags to the Footer component
- Creates a Page component
- removes persist middleware from global stores (causing some bugs)
- adds a stepper component to Harmony page
- fixes bugs with the animated title

To test

- go to harmony
- add two professors, four classes, two rooms, two rooms. 
- select all of the assignment checkboxes
- click find schedule
- click send to schedule

There will be one more PR to allow users to import data. I also plan to add better documentation.

Please let me know if there are any issues! Sorry this is so big. I was not anticipating Harmony would take this much work. 

closes #182
links #136  