### PR TITLE
addressing non-teaching bug in #250

### DIFF
--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -10,7 +10,7 @@ import {
   updateNonIdentifyingCourseInfo,
   updateNonIdentifyingSectionInfo,
 } from "utilities";
-import { getCourse, getSection } from "utilities/services";
+import { getCourse, getSection, isNonTeaching } from "utilities/services";
 import * as cf from "./caseFunctions";
 
 interface ValidFields {
@@ -212,6 +212,7 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
     }
     // Otherwise, add the new section to the existing course
     else {
+      section.isNonTeaching = isNonTeaching(course, section);
       schedule.courses[existingCourseIndex].sections.push(section);
     }
   }

--- a/client-course-schedulizer/src/utilities/services/addSectionService.ts
+++ b/client-course-schedulizer/src/utilities/services/addSectionService.ts
@@ -93,7 +93,13 @@ const convertToSemesterLength = (sl: Half | Intensive | SemesterLengthOption): S
 };
 
 export const getSectionName = (course: Course, section: Section) => {
-  return `${course.prefixes[0]}-${course.number}-${section.letter}`;
+  return `${course.prefixes.length ? course.prefixes[0] : ""}-${course.number}-${section.letter}`;
+};
+
+// if isNonTeaching hasn't already been set, infer it from the 
+// section name (computed from prefix, course number, and section letter all being empty)
+export const isNonTeaching = (course: Course, section: Section) => {
+  return section.isNonTeaching || getSectionName(course, section) === "--";
 };
 
 export const getCourse = (


### PR DESCRIPTION
See discussion in #250.  This adds a computation of whether an item is a non-teaching item if that flag has not been previously set.  This removes the dependency on the SectionName column, which we are no longer exporting (since it is redundant information).