### PR TITLE
Feature/delivery mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,44 +26,45 @@ For more information, please visit the [About Page](https://senior-knights.githu
 
 ## How to use
 
-Detailed information can be found on our [Help Page](https://senior-knights.github.io/course-schedulizer/#/help) (once we make it). Access our production website and upload a CSV following the prescribed specifications:
+Detailed information can be found on our [Help Page](https://senior-knights.github.io/course-schedulizer/#/help) (once we make it). Access our production website and upload a CSV following the prescribed specifications (items marked with * are optional and ignored, but were required in older versions of the app)
 
 - Department: string (like `Mathematics`)
-- Term: [0-9][0-9]/(FA | SP | IN) (like `21/SP` for Spring 2021)
+- *Term: [0-9][0-9]/(FA | SP | IN) (like `21/SP` for Spring 2021)
 - TermStart: mm/dd/yyyy (like `3/29/2021` or `12/1/2022`)
-- AcademicYear: yyyy (like `2021`)
-- SectionName: SubjectCode-CourseNum-SectionCode (like `MATH-252-B`)
+- *AcademicYear: yyyy (like `2021`)
+- *SectionName: SubjectCode-CourseNum-SectionCode (like `MATH-252-B`)
 - SubjectCode: string (like `MATH`)
 - CourseNum: string (like `252` or `252L` for a lab)
 - SectionCode: string (like `B`)
 - CourseLevelCode: pos num (like `200` for a 200 level course)
 - MinimumCredits: pos num (like `3` or `3.5`)
 - FacultyLoad: pos num (like `4` or `4.5`)
-- Used: pos num (like `20`)
-- Day10Used: pos num (like `22`)
-- LocalMax: pos num (like `25`)
-- GlobalMax: pos num (like `30`)
-- RoomCapacity: pos num (like `32`)
+- *Used: pos num (like `20`)
+- *Day10Used: pos num (like `22`)
+- *LocalMax: pos num (like `25`)
+- *GlobalMax: pos num (like `30`)
+- *RoomCapacity: pos num (like `32`)
 - BuildingAndRoom: string (like `HH 345`)
 - MeetingDays: M?T?W?(TH)?F? (like `MWTHF`)
 - MeetingTime: xx:xx(AM | PM) - xx:xx(AM | PM) (like `9:00AM - 9:50AM`)
 - SectionStartDate: mm/dd/yyyy (like `3/29/2021` or `12/1/2022`)
 - SectionEndDate: mm/dd/yyyy (like `3/29/2021` or `12/1/2022`)
-- Building: string (like `HH`)
-- RoomNumber: string (like `345`)
+- *Building: string (like `HH`)
+- *RoomNumber: string (like `345`)
 - MeetingStart: xx:xx(AM | PM) (like `2:30PM`)
-- MeetingStartInternal: xx:xx:xx 24-hour (like `14:30:00`)
+- *MeetingStartInternal: xx:xx:xx 24-hour (like `14:30:00`)
 - MeetingEnd: xx:xx(AM | PM) (like `3:20PM`)
-- MeetingEndInternal: xx:xx:xx 24-hour (like `13:20:00`)
-- Monday: `M` or empty
-- Tuesday: `T` or empty
-- Wednesday: `W` or empty
-- Thursday: `TH` or empty
-- Friday: `F` or empty
+- *MeetingEndInternal: xx:xx:xx 24-hour (like `13:20:00`)
+- *Monday: `M` or empty
+- *Tuesday: `T` or empty
+- *Wednesday: `W` or empty
+- *Thursday: `TH` or empty
+- *Friday: `F` or empty
 - ShortTitle: string (like `Number Theory`)
 - Faculty: string (first and last) (like `Paul Erdos`)
-- SectionStatus: string (like `Active`)
+- *SectionStatus: string (like `Active`)
 - InstructionalMethod: `LEC`, `CPI`, `IND`, `TUT`, or `SEM`
+- DeliveryMode: `In-person`, `Online (synchronous)`, `Online (asynchronous)`, `Hybrid`
 
 ## Development
 

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
@@ -16,6 +16,7 @@ import {
   convertFromSemesterLength,
   emptyMeeting,
   getCourseNames,
+  getDeliveryModes,
   getInstructionalMethods,
   getNumbers,
   getPrefixes,
@@ -238,7 +239,7 @@ export const AddSectionPopover = ({ values }: PopoverValueProps) => {
           </Grid>
           <GridItemAutocomplete
             label="Delivery Mode"
-            options={getInstructionalMethods(schedule)}
+            options={getDeliveryModes(schedule)}
           />
         </Grid>
         <Grid container spacing={SPACING}>

--- a/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
+++ b/client-course-schedulizer/src/components/reuseables/AddSectionPopover/AddSectionPopover.tsx
@@ -17,7 +17,6 @@ import {
   emptyMeeting,
   getCourseNames,
   getDeliveryModes,
-  getInstructionalMethods,
   getNumbers,
   getPrefixes,
   getSectionLetters,

--- a/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
+++ b/client-course-schedulizer/src/utilities/helpers/caseFunctions.ts
@@ -199,6 +199,11 @@ export const instructionalMethodCallback = (value: string, { section }: CaseCall
   section.instructionalMethod = value;
 };
 
+export const deliveryModeCallback = (value: string, { section }: CaseCallbackParams) => {
+  section.deliveryMode = value;
+};
+
+
 export const sectionCallback = (value: string, params: CaseCallbackParams) => {
   if (value === "--" || value.trim() === "") {
     params.section.isNonTeaching = true;
@@ -219,6 +224,7 @@ export const timeCallback = (value: string, params: CaseCallbackParams) => {
 export const nonTeachingActivityCallback = (value: string, params: CaseCallbackParams) => {
   params.section.isNonTeaching = true;
   instructionalMethodCallback(value, params);
+  deliveryModeCallback(value, params);
 };
 
 export const startTimeCase = (value: string): string => {

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -49,6 +49,7 @@ const registrarSpreadsheetFields: ValidFields = {
   Comments: cf.commentsCallback,
   CourseNum: cf.numberCallback,
   Day10Used: cf.day10UsedCallback,
+  DeliveryMode: cf.deliveryModeCallback,
   Department: cf.departmentCallback,
   Faculty: cf.instructorCallback,
   FacultyLoad: cf.facultyHoursCallback,
@@ -165,6 +166,7 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
       section.term,
       section.instructors,
       section.instructionalMethod,
+      section.deliveryMode,
     );
 
     // Update Course fields which were changed

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -10,7 +10,7 @@ import {
   updateNonIdentifyingCourseInfo,
   updateNonIdentifyingSectionInfo,
 } from "utilities";
-import { getCourse, getSection } from "utilities/services";
+import { getCourse, getSection, isNonTeaching } from "utilities/services";
 import * as cf from "./caseFunctions";
 
 interface ValidFields {
@@ -212,6 +212,7 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
     }
     // Otherwise, add the new section to the existing course
     else {
+      section.isNonTeaching = isNonTeaching(course, section);
       schedule.courses[existingCourseIndex].sections.push(section);
     }
   }

--- a/client-course-schedulizer/src/utilities/helpers/readCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/readCSV.ts
@@ -218,6 +218,7 @@ export const insertSectionCourse = (schedule: Schedule, section: Section, course
   }
   // Otherwise, add the new course to the schedule
   else {
+    section.isNonTeaching = isNonTeaching(course, section);
     course.sections.push(section);
     schedule.courses.push(course);
   }

--- a/client-course-schedulizer/src/utilities/helpers/writeFullCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/writeFullCSV.ts
@@ -20,7 +20,7 @@ export const scheduleToFullCSVString = (schedule: Schedule): string => {
   });
 
   let csvStr =
-    "Department,Term,SubjectCode,CourseNum,SectionCode,CourseLevelCode,MinimumCredits,FacultyLoad,BuildingAndRoom,MeetingDays,MeetingTime,SectionStartDate,SectionEndDate,SemesterLength,Building,RoomNumber,MeetingStart,MeetingDurationMinutes,MeetingEnd,ShortTitle,Faculty,SectionStatus,InstructionalMethod,Comments,LastEditTimestamp\n";
+    "Department,Term,SubjectCode,CourseNum,SectionCode,CourseLevelCode,MinimumCredits,FacultyLoad,BuildingAndRoom,MeetingDays,MeetingTime,SectionStartDate,SectionEndDate,SemesterLength,Building,RoomNumber,MeetingStart,MeetingDurationMinutes,MeetingEnd,ShortTitle,Faculty,SectionStatus,InstructionalMethod,DeliveryMode,Comments,LastEditTimestamp\n";
   schedule.courses.forEach((course) => {
     const termOrder = Object.values(Term);
     course.sections = course.sections.sort((a, b): number => {
@@ -124,7 +124,8 @@ export const scheduleToFullCSVString = (schedule: Schedule): string => {
         }","${daysStr}","${meetingTimeStr}",${section.startDate ?? ""},${section.endDate ?? ""},${section.semesterLength ?? ""},"${buildingStr
         }","${roomNumberStr}","${meetingStartStr}","${meetingDurationMinutesStr
         }","${meetingEndStr}","${ section.name ?? course.name 
-        }","${section.instructors.join("\n")}","${section.status ?? ""}","${section.instructionalMethod ?? "" }","${section.comments ?? ""}","${section.timestamp ?? ""}"\n`;
+        }","${section.instructors.join("\n")}","${section.status ?? ""
+        }","${section.instructionalMethod ?? "" }","${section.deliveryMode ?? "" }","${section.comments ?? ""}","${section.timestamp ?? ""}"\n`;
     });
   });
   return csvStr;

--- a/client-course-schedulizer/src/utilities/helpers/writeLoadsCSV.ts
+++ b/client-course-schedulizer/src/utilities/helpers/writeLoadsCSV.ts
@@ -15,9 +15,10 @@ export const scheduleToNonTeachingCSVString = (schedule: Schedule): string => {
 
         // TODO: Should instructionalMethod be used for Non-Teaching Activity or should we add a new field?
         // Construct a row in the output CSV
-        csvStr += `${termStr},${section.instructionalMethod},${section.facultyHours.toFixed(
-          2,
-        )},"${section.instructors.join("\n")}"\n`;
+        csvStr += `${termStr},${section.instructionalMethod},${section.deliveryMode
+          },${section.facultyHours.toFixed(
+            2,
+            )},"${section.instructors.join("\n")}"\n`;
       });
     }
   });

--- a/client-course-schedulizer/src/utilities/hooks/addSectionHooks.ts
+++ b/client-course-schedulizer/src/utilities/hooks/addSectionHooks.ts
@@ -135,7 +135,7 @@ const scrollToUpdatedFacultyRow = (instructor: string) => {
 // a helper to provide consistent naming and retrieve error messages
 export const useInput = <T>(label: string, errors: DeepMap<T, FieldError>) => {
   // (temporary?) hack to match new labels to previously used labels
-  if (label === "Delivery Mode") { label = "Instructional Method" }
+  // if (label === "Delivery Mode") { label = "Instructional Method" }
   if (label === "Course Title") { label = "Name" }
   const name = camelCase(label);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/scheduleInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/dataInterfaces/scheduleInterfaces.ts
@@ -59,6 +59,7 @@ export interface Section {
   comments?: string;
   // Number of students enrolled in this section 10 days into the course
   day10Used?: number;
+  deliveryMode?: string;
   // Like 2/3/2020
   endDate?: string;
   facultyHours: number;
@@ -120,6 +121,7 @@ export const updateIdentifyingSectionInfo = (oldSection: Section, newSection: Se
   oldSection.term = newSection.term;
   oldSection.instructors = newSection.instructors;
   oldSection.instructionalMethod = newSection.instructionalMethod;
+  oldSection.deliveryMode = newSection.deliveryMode;
   return oldSection;
 };
 

--- a/client-course-schedulizer/src/utilities/services/addSectionService.ts
+++ b/client-course-schedulizer/src/utilities/services/addSectionService.ts
@@ -93,7 +93,13 @@ const convertToSemesterLength = (sl: Half | Intensive | SemesterLengthOption): S
 };
 
 export const getSectionName = (course: Course, section: Section) => {
-  return `${course.prefixes[0]}-${course.number}-${section.letter}`;
+  return `${course.prefixes.length ? course.prefixes[0] : ""}-${course.number}-${section.letter}`;
+};
+
+// if isNonTeaching hasn't already been set, infer it from the 
+// section name (computed from prefix, course number, and section letter all being empty)
+export const isNonTeaching = (course: Course, section: Section) => {
+  return section.isNonTeaching || getSectionName(course, section) === "--";
 };
 
 export const getCourse = (

--- a/client-course-schedulizer/src/utilities/services/addSectionService.ts
+++ b/client-course-schedulizer/src/utilities/services/addSectionService.ts
@@ -37,7 +37,7 @@ export interface SectionInput {
   facultyHours?: Section["facultyHours"];
   globalMax?: Section["globalMax"];
   halfSemester?: Half;
-  instructionalMethod?: Section["instructionalMethod"];
+  // instructionalMethod?: Section["instructionalMethod"];
   instructor: Instructor[];
   intensiveSemester?: Intensive;
   localMax?: Section["localMax"];
@@ -137,25 +137,25 @@ export const getSection = (
   return sections.length > 0 ? sections[0] : undefined;
 };
 
-// Deprecated, replaced by removeMeeting
-// TODO: Remove?
-const removeSection = (
-  schedule: Schedule,
-  letter: Section["letter"],
-  term: Section["term"],
-  instructors: Section["instructors"],
-  courseIndex: number,
-) => {
-  schedule.courses[courseIndex].sections = filter(
-    schedule.courses[courseIndex].sections,
-    (section) => {
-      return (
-        section.letter !== letter || section.term !== term || section.instructors !== instructors
-      );
-    },
-  );
-  // TODO: Delete course if no sections left?
-};
+// // Deprecated, replaced by removeMeeting
+// // TODO: Remove?
+// const removeSection = (
+//   schedule: Schedule,
+//   letter: Section["letter"],
+//   term: Section["term"],
+//   instructors: Section["instructors"],
+//   courseIndex: number,
+// ) => {
+//   schedule.courses[courseIndex].sections = filter(
+//     schedule.courses[courseIndex].sections,
+//     (section) => {
+//       return (
+//         section.letter !== letter || section.term !== term || section.instructors !== instructors
+//       );
+//     },
+//   );
+//   // TODO: Delete course if no sections left?
+// };
 
 /* Used to map the input from the popover form to the
  internal JSON object type.  */
@@ -198,7 +198,7 @@ export const mapInternalTypesToInput = (data?: CourseSectionMeeting): SectionInp
     convertFromSemesterLength(data?.section.semesterLength) === SemesterLengthOption.HalfSemester
       ? data?.section.semesterLength
       : SemesterLength.HalfFirst) as unknown) as Half,
-    instructionalMethod: data?.section.instructionalMethod ?? "",   // TODO: should this be "LEC"?
+    // instructionalMethod: data?.section.instructionalMethod ?? "",   // TODO: should this be "LEC"?
     instructor: data?.section.instructors ?? [],
     intensiveSemester: ((data?.section.semesterLength &&
     convertFromSemesterLength(data?.section.semesterLength) ===
@@ -244,7 +244,7 @@ const createNewSectionFromInput = (data: SectionInput): Section => {
     endDate: "",
     facultyHours: Number(data.facultyHours),
     globalMax: data.globalMax,
-    instructionalMethod: data.instructionalMethod,
+    // instructionalMethod: data.instructionalMethod,
     instructors: data.instructor,
     letter: data.section,
     localMax: data.localMax,
@@ -283,46 +283,46 @@ const createNewCourseFromInput = (data: SectionInput): Course => {
   };
 };
 
-// Deprecated, replaced by handleOldMeeting
-// TODO: Remove?
-export const handleOldSection = (
-  oldData: CourseSectionMeeting | undefined,
-  newSection: Section,
-  removeOldSection: boolean,
-  schedule: Schedule,
-) => {
-  const oldSection = oldData?.section;
-  if (oldSection) {
-    // If the year, term, and semester length haven't changed...
-    if (
-      String(newSection.year) === String(oldSection.year) &&
-      newSection.term === oldSection.term &&
-      newSection.semesterLength === oldSection.semesterLength
-    ) {
-      // Update the new Section to match the date fields of the old Section
-      newSection.termStart = oldSection.termStart;
-      newSection.startDate = oldSection.startDate;
-      newSection.endDate = oldSection.endDate;
-    }
+// // Deprecated, replaced by handleOldMeeting
+// // TODO: Remove?
+// export const handleOldSection = (
+//   oldData: CourseSectionMeeting | undefined,
+//   newSection: Section,
+//   removeOldSection: boolean,
+//   schedule: Schedule,
+// ) => {
+//   const oldSection = oldData?.section;
+//   if (oldSection) {
+//     // If the year, term, and semester length haven't changed...
+//     if (
+//       String(newSection.year) === String(oldSection.year) &&
+//       newSection.term === oldSection.term &&
+//       newSection.semesterLength === oldSection.semesterLength
+//     ) {
+//       // Update the new Section to match the date fields of the old Section
+//       newSection.termStart = oldSection.termStart;
+//       newSection.startDate = oldSection.startDate;
+//       newSection.endDate = oldSection.endDate;
+//     }
 
-    // Remove the old version of the Section
-    if (removeOldSection) {
-      removeSectionFromSchedule(oldData, schedule, oldSection);
-    }
-  }
-};
+//     // Remove the old version of the Section
+//     if (removeOldSection) {
+//       removeSectionFromSchedule(oldData, schedule, oldSection);
+//     }
+//   }
+// };
 
-// Deprecated, replaced by removeMeetingFromSchedule
-// TODO: Remove?
-export const removeSectionFromSchedule = (
-  data: CourseSectionMeeting | undefined,
-  schedule: Schedule,
-  section: Section,
-) => {
-  const oldCourse = data?.course;
-  const courseIndex = indexOf(schedule.courses, oldCourse);
-  removeSection(schedule, section.letter, section.term, section.instructors, courseIndex);
-};
+// // Deprecated, replaced by removeMeetingFromSchedule
+// // TODO: Remove?
+// export const removeSectionFromSchedule = (
+//   data: CourseSectionMeeting | undefined,
+//   schedule: Schedule,
+//   section: Section,
+// ) => {
+//   const oldCourse = data?.course;
+//   const courseIndex = indexOf(schedule.courses, oldCourse);
+//   removeSection(schedule, section.letter, section.term, section.instructors, courseIndex);
+// };
 
 export const addFalseToDaysCheckboxList = (days?: Day[]): CheckboxDays => {
   const weekdays = Object.values(Day).filter((day) => {

--- a/client-course-schedulizer/src/utilities/services/addSectionService.ts
+++ b/client-course-schedulizer/src/utilities/services/addSectionService.ts
@@ -31,6 +31,7 @@ export interface SectionInput {
   comments?: Section["comments"];
   day10Used?: Section["day10Used"];
   days: CheckboxDays;
+  deliveryMode?: Section["deliveryMode"];
   department?: Course["department"];
   duration?: Meeting["duration"];
   facultyHours?: Section["facultyHours"];
@@ -121,6 +122,7 @@ export const getSection = (
   term: Section["term"],
   instructors: Section["instructors"],
   instructionalMethod: Section["instructionalMethod"],
+  deliveryMode: Section["deliveryMode"],
 ) => {
   const course = getCourse(schedule, prefixes, courseNumber);
   const sections = filter(course?.sections, (section) => {
@@ -128,7 +130,8 @@ export const getSection = (
       section.letter === letter &&
       section.term === term &&
       isEqual(section.instructors, instructors) &&
-      section.instructionalMethod === instructionalMethod
+      section.instructionalMethod === instructionalMethod &&
+      section.deliveryMode === deliveryMode
     );
   });
   return sections.length > 0 ? sections[0] : undefined;
@@ -183,6 +186,7 @@ export const mapInternalTypesToInput = (data?: CourseSectionMeeting): SectionInp
     comments: data?.section.comments?.trim() === "" ? undefined : data?.section.comments,
     day10Used: data?.section.day10Used,
     days,
+    deliveryMode: data?.section.deliveryMode ?? "",  // TODO: should this be "In-person"?
     department: data?.course.department,
     duration: data?.meeting?.duration,
     facultyHours:
@@ -194,7 +198,7 @@ export const mapInternalTypesToInput = (data?: CourseSectionMeeting): SectionInp
     convertFromSemesterLength(data?.section.semesterLength) === SemesterLengthOption.HalfSemester
       ? data?.section.semesterLength
       : SemesterLength.HalfFirst) as unknown) as Half,
-    instructionalMethod: data?.section.instructionalMethod ?? "In-person",
+    instructionalMethod: data?.section.instructionalMethod ?? "",   // TODO: should this be "LEC"?
     instructor: data?.section.instructors ?? [],
     intensiveSemester: ((data?.section.semesterLength &&
     convertFromSemesterLength(data?.section.semesterLength) ===
@@ -236,6 +240,7 @@ const createNewSectionFromInput = (data: SectionInput): Section => {
     anticipatedSize: data.anticipatedSize,
     comments: data.comments,
     day10Used: data.day10Used,
+    deliveryMode: data.deliveryMode,
     endDate: "",
     facultyHours: Number(data.facultyHours),
     globalMax: data.globalMax,

--- a/client-course-schedulizer/src/utilities/services/scheduleService.ts
+++ b/client-course-schedulizer/src/utilities/services/scheduleService.ts
@@ -289,6 +289,8 @@ export const getSectionLetters = (schedule: Schedule) => {
   return letters.sort();
 };
 
+// get list of instructional methods already in use in the Schedule
+// used for autocompletion
 export const getInstructionalMethods = (schedule: Schedule) => {
   const instructionalMethods: string[] = [];
   forEach(schedule.courses, (course) => {
@@ -305,6 +307,8 @@ export const getInstructionalMethods = (schedule: Schedule) => {
   return instructionalMethods.sort();
 };
 
+// get list of delivery modes already in use in the Schedule
+// used for autocompletion
 export const getDeliveryModes = (schedule: Schedule) => {
   const deliveryModes: string[] = [];
   forEach(schedule.courses, (course) => {

--- a/client-course-schedulizer/src/utilities/services/scheduleService.ts
+++ b/client-course-schedulizer/src/utilities/services/scheduleService.ts
@@ -305,6 +305,22 @@ export const getInstructionalMethods = (schedule: Schedule) => {
   return instructionalMethods.sort();
 };
 
+export const getDeliveryModes = (schedule: Schedule) => {
+  const deliveryModes: string[] = [];
+  forEach(schedule.courses, (course) => {
+    forEach(course.sections, (section) => {
+      if (
+        section.deliveryMode &&
+        !deliveryModes.includes(section.deliveryMode) &&
+        !section.isNonTeaching
+      ) {
+        deliveryModes.push(section.deliveryMode);
+      }
+    });
+  });
+  return deliveryModes.sort();
+};
+
 export const getDepts = (schedule: Schedule) => {
   const departments: string[] = [];
   forEach(schedule.courses, (course) => {

--- a/client-course-schedulizer/src/utilities/services/scheduleService.ts
+++ b/client-course-schedulizer/src/utilities/services/scheduleService.ts
@@ -289,23 +289,25 @@ export const getSectionLetters = (schedule: Schedule) => {
   return letters.sort();
 };
 
-// get list of instructional methods already in use in the Schedule
-// used for autocompletion
-export const getInstructionalMethods = (schedule: Schedule) => {
-  const instructionalMethods: string[] = [];
-  forEach(schedule.courses, (course) => {
-    forEach(course.sections, (section) => {
-      if (
-        section.instructionalMethod &&
-        !instructionalMethods.includes(section.instructionalMethod) &&
-        !section.isNonTeaching
-      ) {
-        instructionalMethods.push(section.instructionalMethod);
-      }
-    });
-  });
-  return instructionalMethods.sort();
-};
+// // get list of instructional methods already in use in the Schedule
+// // used for autocompletion
+// // deprecated -- using getDeliveryModes() now
+//
+// export const getInstructionalMethods = (schedule: Schedule) => {
+//   const instructionalMethods: string[] = [];
+//   forEach(schedule.courses, (course) => {
+//     forEach(course.sections, (section) => {
+//       if (
+//         section.instructionalMethod &&
+//         !instructionalMethods.includes(section.instructionalMethod) &&
+//         !section.isNonTeaching
+//       ) {
+//         instructionalMethods.push(section.instructionalMethod);
+//       }
+//     });
+//   });
+//   return instructionalMethods.sort();
+// };
 
 // get list of delivery modes already in use in the Schedule
 // used for autocompletion

--- a/client-course-schedulizer/src/utilities/services/validation/popover.ts
+++ b/client-course-schedulizer/src/utilities/services/validation/popover.ts
@@ -44,6 +44,7 @@ export const addSectionSchema = object().shape({
     .transform(emptyStringToNull)
     .nullable(),
   days: array().transform(removeUncheckedValues),
+  deliveryMode: string().nullable(),
   department: string().nullable(),
   duration: number()
     .typeError("duration must be a number")


### PR DESCRIPTION
I've added a columns to the data: delivery mode.

* This will be the new lingo going forward in the workday world
* I've left instructional method in place because
    * it is used to track non-teach activities (so we could just rename it and use it for that purpose ONLY)
    * technically, instructional method still exists, it just isn't something that people creating the schedule can change on a per-section basis -- it is already in the workday system at the course-level (ie, decided upon when the course is proposed, not when the schedule is created).

The behavior of the pull request:

* uses the add section popover to edit the delivery mode field
* uses the instructional mode field for non-teaching activities
* leaves any data in delivery mode as is from old schedules (so you will see things like LEC, SEM, etc. for now).  

I've done several tests of creating classes and not teaching activities, importing and exporting.  So far, everything I've tried has worked as I've expected.

This deals with #268 and supersedes #269.