### PR TITLE
add selector for semester part

### DIFF
--- a/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
+++ b/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.scss
@@ -20,7 +20,8 @@
 }
 
 .toolbar-left {
-  width: 35%;
+  margin-left: 4 * $spacing;
+  width: 20%;
 }
 
 .toolbar-right {

--- a/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.tsx
+++ b/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.tsx
@@ -1,6 +1,7 @@
-import { AddSectionButton, ColorSelector, Searchbar, SemesterSelector } from "components";
+import { AddSectionButton, ColorSelector, Searchbar, SemesterSelector} from "components";
 import React, { useContext } from "react";
 import { AppContext } from "utilities/contexts";
+import { SemesterPartSelector } from "../SemesterPartSelector";
 import "./ScheduleToolbar.scss";
 
 export const ScheduleToolbar = () => {
@@ -13,6 +14,7 @@ export const ScheduleToolbar = () => {
       <div className="toolbar-left">
         <Searchbar />
         <ColorSelector />
+        <SemesterPartSelector />
       </div>
       <div>{fileUrl ? `Imported URL: ${fileUrl}` : ""}</div>
       <div className="toolbar-right">

--- a/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.tsx
+++ b/client-course-schedulizer/src/components/Toolbar/ScheduleToolbar/ScheduleToolbar.tsx
@@ -12,7 +12,6 @@ export const ScheduleToolbar = () => {
   return (
     <div className="schedule-toolbar">
       <div className="toolbar-left">
-        <Searchbar />
         <ColorSelector />
         <SemesterPartSelector />
       </div>

--- a/client-course-schedulizer/src/components/Toolbar/SemesterPartSelector/SemesterPartSelector.tsx
+++ b/client-course-schedulizer/src/components/Toolbar/SemesterPartSelector/SemesterPartSelector.tsx
@@ -1,0 +1,35 @@
+import { InputLabel, MenuItem, Select } from "@material-ui/core";
+import React, { ChangeEvent, useContext } from "react";
+import { AppContext } from "utilities/contexts";
+import { SemesterLength } from "utilities/interfaces";
+import "./SemesterPartSelector.scss";
+
+export const SemesterPartSelector = () => {
+  const {
+    appState: { selectedSemesterPart },
+    appDispatch,
+    setIsCSVLoading,
+  } = useContext(AppContext);
+
+  const handleSemesterPartChange = (event: ChangeEvent<{ value: unknown }>) => {
+    setIsCSVLoading(true);
+    const semesterPart = event.target.value as SemesterLength;
+    appDispatch({ payload: { selectedSemesterPart: semesterPart }, type: "setSelectedSemesterPart" });
+    setIsCSVLoading(false);
+  };
+
+  return (
+    <div>
+      <InputLabel id="label">Semester Part</InputLabel>
+      <Select id="semester-part-select" onChange={handleSemesterPartChange} value={selectedSemesterPart}>
+        <MenuItem value={SemesterLength.Full}>Full</MenuItem>
+        <MenuItem value={SemesterLength.HalfFirst}>First Half</MenuItem>
+        <MenuItem value={SemesterLength.HalfSecond}>Second Half</MenuItem>
+        <MenuItem value={SemesterLength.IntensiveA}>Intensive A</MenuItem>
+        <MenuItem value={SemesterLength.IntensiveB}>Intensive B</MenuItem>
+        <MenuItem value={SemesterLength.IntensiveC}>Intensive C</MenuItem>
+        <MenuItem value={SemesterLength.IntensiveD}>Intensive D</MenuItem>
+      </Select>
+    </div>
+  );
+};

--- a/client-course-schedulizer/src/components/Toolbar/SemesterPartSelector/index.ts
+++ b/client-course-schedulizer/src/components/Toolbar/SemesterPartSelector/index.ts
@@ -1,0 +1,1 @@
+export * from "./SemesterPartSelector";

--- a/client-course-schedulizer/src/components/reuseables/Schedule/ScheduleBase.tsx
+++ b/client-course-schedulizer/src/components/reuseables/Schedule/ScheduleBase.tsx
@@ -37,7 +37,7 @@ export const ScheduleBase = ({
   ...calendarOptions
 }: ScheduleBaseProps) => {
   const {
-    appState: { colorBy, selectedTerm, slotMaxTime, slotMinTime },
+    appState: { colorBy, selectedTerm, selectedSemesterPart, slotMaxTime, slotMinTime },
   } = useAppContext();
   const [popupData, setPopupData] = useState<CourseSectionMeeting>();
 
@@ -67,7 +67,7 @@ export const ScheduleBase = ({
 
   // Filter out events from other terms
   const filteredEvents = useMemo(() => {
-    return filterEventsByTerm(groupedEvents, selectedTerm);
+    return filterEventsByTerm(groupedEvents, selectedTerm, selectedSemesterPart);
   }, [groupedEvents, selectedTerm]);
 
   // Filter out headers with no events

--- a/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
+++ b/client-course-schedulizer/src/utilities/interfaces/appInterfaces.ts
@@ -1,6 +1,6 @@
 import { loadLocal } from "utilities/hooks/useLocal";
 import { HarmonyClass } from "utilities/services";
-import { Schedule, Term } from "./dataInterfaces";
+import { Schedule, SemesterLength, Term } from "./dataInterfaces";
 
 export enum ColorBy {
   Level,
@@ -27,6 +27,7 @@ export interface AppState {
   rooms: string[];
   schedule: Schedule;
   schedulizerTab: SchedulizerTab;
+  selectedSemesterPart: SemesterLength;
   selectedTerm: Term;
   slotMaxTime: string;
   slotMinTime: string;
@@ -46,6 +47,7 @@ export const initialAppState: AppState = loadLocal("appState") || {
   rooms: [],
   schedule: { courses: [], numDistinctSchedules: 0 },
   schedulizerTab: 0,
+  selectedSemesterPart: SemesterLength.Full,
   selectedTerm: Term.Fall,
   slotMaxTime: "22:00",
   slotMinTime: "6:00",
@@ -69,5 +71,5 @@ if (!initialAppState.rooms) {
 // structure of actions that can be sent to app dispatch
 export interface AppAction {
   payload: Partial<AppState>;
-  type: "setScheduleData" | "setSelectedTerm" | "setFileUrl" | "setColorBy" | "setSchedulizerTab" | "setConstraints"; // add | to add more actions in the future
+  type: "setScheduleData" | "setSelectedTerm" | "setFileUrl" | "setColorBy" | "setSchedulizerTab" | "setSelectedSemesterPart" | "setConstraints"; // add | to add more actions in the future
 }

--- a/client-course-schedulizer/src/utilities/reducers/appReducer.ts
+++ b/client-course-schedulizer/src/utilities/reducers/appReducer.ts
@@ -1,5 +1,5 @@
 import { voidFn } from "utilities";
-import { AppAction, AppState, ColorBy, SchedulizerTab, Term } from "utilities/interfaces";
+import { AppAction, AppState, ColorBy, SchedulizerTab, SemesterLength, Term } from "utilities/interfaces";
 import {
   getClasses,
   getDepts,
@@ -52,6 +52,12 @@ export const reducer = (actionCallback: (item: AppState) => void = voidFn) => {
         let { colorBy } = action.payload;
         colorBy = colorBy || ColorBy.Level;
         newState = { ...state, colorBy };
+        break;
+      }
+      case "setSelectedSemesterPart": {
+        let { selectedSemesterPart } = action.payload;
+        selectedSemesterPart = selectedSemesterPart || SemesterLength.Full;
+        newState = { ...state, selectedSemesterPart };
         break;
       }
       case "setSchedulizerTab": {

--- a/client-course-schedulizer/src/utilities/services/scheduleService.ts
+++ b/client-course-schedulizer/src/utilities/services/scheduleService.ts
@@ -6,8 +6,8 @@ import hash from "object-hash";
 import randomColor from "randomcolor";
 import { enumArray, WILDCARD_COLOR } from "utilities";
 import { INITIAL_DATE } from "utilities/constants";
-import { ColorBy, Day, Location, Meeting, Schedule, Section, Term } from "utilities/interfaces";
-import { Constraints, findConflicts } from "./conflictsService";
+import { ColorBy, Day, Location, Meeting, Schedule, Section, SemesterLength, Term } from "utilities/interfaces";
+import { Constraints, findConflicts, termsOverlap } from "./conflictsService";
 
 // Returns a list of hours to display on the Schedule
 // TODO: add better types for timing, maybe: https://stackoverflow.com/questions/51445767/how-to-define-a-regex-matched-string-type-in-typescript
@@ -131,11 +131,15 @@ export const getMinAndMaxTimes = (schedule: Schedule) => {
   };
 };
 
-export const filterEventsByTerm = (groupedEvents: GroupedEvents, term: Term) => {
+export const filterEventsByTerm = (
+  groupedEvents: GroupedEvents, 
+  term: Term, 
+  semesterLength: SemesterLength = SemesterLength.HalfSecond) => {
   const tempGroupedEvents: GroupedEvents = {};
   forOwn(groupedEvents, (_, key) => {
     tempGroupedEvents[key] = filter(groupedEvents[key], (e) => {
-      return e.extendedProps?.section.term === term;
+      return e.extendedProps?.section.term === term && 
+             termsOverlap(e.extendedProps?.section.semesterLength, semesterLength);
     });
   });
   return tempGroupedEvents;

--- a/client-course-schedulizer/src/utilities/services/scheduleService.ts
+++ b/client-course-schedulizer/src/utilities/services/scheduleService.ts
@@ -134,7 +134,7 @@ export const getMinAndMaxTimes = (schedule: Schedule) => {
 export const filterEventsByTerm = (
   groupedEvents: GroupedEvents, 
   term: Term, 
-  semesterLength: SemesterLength = SemesterLength.HalfSecond) => {
+  semesterLength: SemesterLength = SemesterLength.Full) => {
   const tempGroupedEvents: GroupedEvents = {};
   forOwn(groupedEvents, (_, key) => {
     tempGroupedEvents[key] = filter(groupedEvents[key], (e) => {


### PR DESCRIPTION
This addresses #308.

I've added a selector for semester part.  It works much like the color-by selector.  All courses with intersecting terms are displayed. So if you pick "First Half", you will see Full, First Half, A, and B courses since all of those meet during the first half of the semester.

This my need revisiting if/when we implement custom terms.  But that is disabled for now.