### PR TITLE
Resetting CI so that warnings are not treated as errors on pnpm build

### DIFF
--- a/client-course-schedulizer/package.json
+++ b/client-course-schedulizer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": ".",
   "scripts": {
-    "build": "react-scripts build",
+    "build": "CI=false && react-scripts build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Turning off CI so that warnings don't create errors