### PR TITLE
Add section fixed

### DIFF
--- a/client-course-schedulizer/csv/full_schedule_2025.csv
+++ b/client-course-schedulizer/csv/full_schedule_2025.csv
@@ -1,0 +1,184 @@
+Department,Term,SubjectCode,CourseNum,SectionCode,CourseLevelCode,MinimumCredits,FacultyLoad,BuildingAndRoom,MeetingDays,MeetingTime,SectionStartDate,SectionEndDate,SemesterLength,Building,RoomNumber,MeetingStart,MeetingDurationMinutes,MeetingEnd,ShortTitle,Faculty,SectionStatus,InstructionalMethod,DeliveryMode,Group,Comments,LastEditTimestamp
+"",FA,"",,,,0, 4,"","","",,,Full,"","","","","","","Eric Araujo","","Kuiper Seminar","","","","2024-04-29T16:50:27-04:00"
+"",FA,"",,,,0, 4,"","","",,,Full,"","","","","","","Fernando Pasquini Santos","","CRF","","","","2024-04-29T18:06:54-04:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Derek C Schuurman","","2 CS 396/8 projects","","","","2024-09-18T12:39:37-04:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Kenneth C Arnold","","2 CS 396/398 projects","","","","2024-09-18T12:42:15-04:00"
+"",FA,"",,,,0, 8,"","","",,,Full,"","","","","","","Derek C Schuurman","","Legacy CRF","","","","2024-09-18T12:43:20-04:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Harry Plantinga","","2 CS 396/8 projects","","","","2024-10-02T10:36:03-04:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Keith VanderLinden","","2 CS 396/8 projects","","","","2024-10-24T16:03:53-04:00"
+"",FA,"",,,,0, 12,"","","",,,Full,"","","","","","","Harry Plantinga","","CCEL","","","","2024-10-24T16:54:53-04:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Eric Araujo","","2 CS 396/8 projects","","","","2024-10-26T11:42:56-04:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Rocky Chang","","2 CS 396/8 projects","","","","2024-10-26T12:04:04-04:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Keith VanderLinden","","Chair","","","","2024-11-09T13:32:14-05:00"
+"",FA,"",,,,0, 5,"","","",,,Full,"","","","","","","Kenneth C Arnold","","NSF","","","","2024-11-11T18:37:42-05:00"
+"",FA,"",,,,0, 2,"","","",,,Full,"","","","","","","Fernando Pasquini Santos","","2 CS 396/8 projects","","","","2024-11-12T16:58:35-05:00"
+"",SP,"",,,,0, 2,"","","",,,Full,"","","","","","","Victor T. Norman","","2 Senior Project Teams","","","","2024-11-07T13:19:45-05:00"
+"",SP,"",,,,0, 4,"","","",,,Full,"","","","","","","Rocky Chang","","CRF","","","","2024-11-09T13:22:51-05:00"
+"",SP,"",,,,0, 4,"","","",,,Full,"","","","","","","Derek C Schuurman","","Chair","","","","2024-11-09T13:32:06-05:00"
+"",,"",,,,, 4,"","","",,,,"","","","","","","Fernando Pasquini Santos","","CCCS CRF","","","","2025-04-10T10:06:50-04:00"
+"Computer Science",FA,"*",*,*,,0, 0,"*
+*
+*","MTWTHF
+MWF
+TTH","4:00PM - 6:15PM
+10:30AM - 10:50AM
+9:50AM - 10:10AM",,,Full,"*
+*
+*","
+
+","4:00 PM
+10:30 AM
+9:50 AM","135
+20
+20","6:15 PM
+10:50 AM
+10:10 AM","","*","Active","LEC","","","","2022-06-13T13:09:39-04:00"
+"Computer Science",SP,"*",*,*,,0, 0,"*
+*
+*","MTWTHF
+MWF
+TTH","4:00PM - 6:15PM
+10:30AM - 10:50AM
+9:50AM - 10:10AM",,,Full,"*
+*
+*","
+
+","4:00 PM
+10:30 AM
+9:50 AM","135
+20
+20","6:15 PM
+10:50 AM
+10:10 AM","","*","Active","LEC","","","","2022-06-13T13:09:39-04:00"
+"Computer Science",FA,"CS",100,A,100,4, 4,"SB 354","TTH","10:20AM - 12:00PM",,,Full,"SB","354","10:20 AM","100","12:00 PM","Creating Interactive Web Media","David Meyer","Active","LEC","","","","2022-06-14T13:37:57-04:00"
+"Computer Science",FA,"CS",104,A,100,1, 2,"SB 372","MWF","12:15PM - 1:20PM",,,First,"SB","372","12:15 PM","65","1:20 PM","Applied Computing","Keith VanderLinden","","","","","","2024-11-12T09:21:04-05:00"
+"Computer Science",FA,"CS",104,B,100,1, 2,"SB 372","MWF","12:15PM - 1:20PM",,,Second,"SB","372","12:15 PM","65","1:20 PM","Applied Computing","Keith VanderLinden","","","","","","2024-11-27T13:24:37-05:00"
+"Computer Science",FA,"CS",104L,A,100,1, 0.5,"SB 372","T","12:15PM - 1:55PM",,,First,"SB","372","12:15 PM","100","1:55 PM","Applied Computing","Christopher Wieringa","","","","","","2024-11-11T18:57:58-05:00"
+"Computer Science",FA,"CS",104L,B,100,1, 0.5,"SB 372","T","2:10PM - 3:50PM",,,First,"SB","372","2:10 PM","100","3:50 PM","Applied Computing","Fernando Pasquini Santos","","","","","","2024-11-12T16:58:00-05:00"
+"Computer Science",FA,"CS",104L,C,100,1, 0.5,"SB 372","T","12:15PM - 1:55PM",,,Second,"SB","372","12:15 PM","100","1:55 PM","Applied Computing","Christopher Wieringa","","","","","","2024-11-11T18:59:34-05:00"
+"Computer Science",FA,"CS",104L,D,100,1, 0.5,"SB 372","T","2:10PM - 3:50PM",,,Second,"SB","372","2:10 PM","100","3:50 PM","Applied Computing","Fernando Pasquini Santos","","","","","","2024-11-12T16:58:14-05:00"
+"Computer Science",FA,"CS",106,A,100,3, 4,"SB 372","MWF","2:45PM - 3:50PM",,,Full,"SB","372","2:45 PM","65","3:50 PM","Intro to Computing","Kenneth C Arnold","","","","","","2025-02-04T14:19:55-05:00"
+"Computer Science",FA,"CS",106L,A,100,1, 1,"SB 372","TH","10:20AM - 12:00PM",,,Full,"SB","372","10:20 AM","100","12:00 PM","Intro to Computing Lab","Kenneth C Arnold","","","","","","2025-02-04T14:20:13-05:00"
+"Computer Science",FA,"CS",108,A,100,3, 4,"SB 372","MWF","11:00AM - 12:05PM",,,Full,"SB","372","11:00 AM","65","12:05 PM","Intro to Computing","Rocky Chang","","","","","","2025-02-04T14:20:37-05:00"
+"Computer Science",SP,"CS",108,A,100,3, 4,"SB 382","MWF","1:30PM - 2:35PM",,,Full,"SB","382","1:30 PM","65","2:35 PM","Intro to Computing","Kenneth C Arnold","","","","","","2025-02-04T14:25:21-05:00"
+"Computer Science",FA,"CS",108,B,100,3, 4,"SB 372","MWF","1:30PM - 2:35PM",,,Full,"SB","372","1:30 PM","65","2:35 PM","Intro to Computing Lab","Rocky Chang","","","","","","2025-02-04T14:20:46-05:00"
+"Computer Science",SP,"CS",108,B,100,3, 4,"SB 382","MWF","2:45PM - 3:50PM",,,Full,"SB","382","2:45 PM","65","3:50 PM","Intro to Computing","Fernando Pasquini Santos","","","","","","2024-10-03T11:39:38-04:00"
+"Computer Science",FA,"CS",108L,A,100,1, 1,"SB 372","TH","8:00AM - 9:40AM",,,Full,"SB","372","8:00 AM","100","9:40 AM","Intro to Computing Lab","Rocky Chang","","","","","","2025-02-04T14:21:21-05:00"
+"Computer Science",SP,"CS",108L,A,100,1, 1,"SB 372","TH","8:00AM - 9:40AM",,,Full,"SB","372","8:00 AM","100","9:40 AM","Intro to Computing Lab","Kenneth C Arnold","","","","","","2025-02-04T14:25:30-05:00"
+"Computer Science",FA,"CS",108L,B,100,1, 1,"SB 372","TH","12:15PM - 1:55PM",,,Full,"SB","372","12:15 PM","100","1:55 PM","Intro to Computing Lab","Rocky Chang","","","","","","2025-02-04T14:21:33-05:00"
+"Computer Science",SP,"CS",108L,B,100,1, 1,"SB 372","TH","10:20AM - 12:00PM",,,Full,"SB","372","10:20 AM","100","12:00 PM","Intro to Computing Lab","Fernando Pasquini Santos","","","","","","2024-10-26T12:10:00-04:00"
+"Computer Science",FA,"CS",112,A,100,3, 4,"SB 382","MWF","12:15PM - 1:20PM",,,Full,"SB","382","12:15 PM","65","1:20 PM","Intro to Data Structures","Eric Araujo","","","","","","2025-02-04T14:45:21-05:00"
+"Computer Science",SP,"CS",112,A,100,3, 4,"SB 372","MWF","11:00AM - 12:05PM",,,Full,"SB","372","11:00 AM","65","12:05 PM","Intro to Data Structures","Victor T. Norman","","","","","","2024-11-07T15:00:56-05:00"
+"Computer Science",FA,"CS",112,B,100,3, 4,"SB 382","MWF","1:30PM - 2:35PM",,,Full,"SB","382","1:30 PM","65","2:35 PM","Intro to Data Structures","Eric Araujo","","","","","","2025-02-04T14:45:11-05:00"
+"Computer Science",SP,"CS",112,B,100,3, 4,"SB 372","MWF","12:15PM - 1:20PM",,,Full,"SB","372","12:15 PM","65","1:20 PM","Intro to Data Structures","Victor T. Norman","","","","","","2024-11-07T14:38:48-05:00"
+"Computer Science",FA,"CS",112L,A,100,1, 1,"SB 372","T","8:00AM - 9:40AM",,,Full,"SB","372","8:00 AM","100","9:40 AM","Intro to Data Structures Lab","Christopher Wieringa","","","","","","2024-11-09T13:41:39-05:00"
+"Computer Science",SP,"CS",112L,A,100,1, 1,"SB 372","T","8:00AM - 9:40AM",,,Full,"SB","372","8:00 AM","100","9:40 AM","Intro to Data Structures Lab","Eric Araujo","","","","","","2024-01-15T17:33:05-05:00"
+"Computer Science",FA,"CS",112L,B,100,1, 1,"SB 372","T","10:20AM - 12:00PM",,,Full,"SB","372","10:20 AM","100","12:00 PM","Intro to Data Structures Lab","Christopher Wieringa","","","","","","2024-11-09T13:41:50-05:00"
+"Computer Science",SP,"CS",112L,B,100,1, 1,"SB 372","T","10:20AM - 12:00PM",,,Full,"SB","372","10:20 AM","100","12:00 PM","Intro to Data Structures Lab","Eric Araujo","","","","","","2024-09-10T10:41:49-04:00"
+"Computer Science",FA,"CS",195,A,100,0, 0.5,"SB 010","T","3:05PM - 3:55PM",,,Full,"SB","010","3:05 PM","50","3:55 PM","Intro Computing Seminar","Derek C Schuurman","","","","","","2024-11-09T13:40:34-05:00"
+"Computer Science",SP,"CS",195,A,100,0, 0.5,"SB 010","T","3:05PM - 3:55PM",,,Full,"SB","010","3:05 PM","50","3:55 PM","Computing Seminar","Derek C Schuurman","","","","","","2024-11-09T13:41:02-05:00"
+"Computer Science",FA,"CS",212,A,200,4, 4,"SB 372","MWF","8:00AM - 9:05AM",,,Full,"SB","372","8:00 AM","65","9:05 AM","Data Structures & Algorithms","Harry Plantinga","","","","","","2024-01-22T14:19:27-05:00"
+"Computer Science",FA,"CS",212,B,200,4, 4,"SB 372","MWF","9:15AM - 10:20AM",,,Full,"SB","372","9:15 AM","65","10:20 AM","Data Structures & Algorithms","Harry Plantinga","","","","","","2024-01-22T14:19:47-05:00"
+"Computer Science",SP,"CS",214,A,200,4, 4,"SB 372
+SB 354","MW
+F","2:45PM - 3:50PM
+2:45PM - 5:05PM",,,Full,"SB
+SB","372
+354","2:45 PM
+2:45 PM","65
+140","3:50 PM
+5:05 PM","Programming Lang Concepts","Eric Araujo","","","","","","2022-06-10T13:20:27-04:00"
+"Computer Science",SP,"CS",214,B,200,4, 4,"SB 372
+SB 372","F
+MW","2:45PM - 5:05PM
+4:00PM - 5:05PM",,,Full,"SB
+SB","372
+372","2:45 PM
+4:00 PM","140
+65","5:05 PM
+5:05 PM","Programming Lang Concepts","David Meyer","","","","","","2022-06-10T13:20:27-04:00"
+"Computer Science",SP,"CS",232,A,200,4, 4,"SB 372","MWF","8:00AM - 9:05AM",,,Full,"SB","372","8:00 AM","65","9:05 AM","Operating Systems and Networki","Rocky Chang","","","","","","2024-11-12T16:56:20-05:00"
+"Computer Science",SP,"CS",232,B,200,4, 4,"SB 372","MWF","9:15AM - 10:20AM",,,Full,"SB","372","9:15 AM","65","10:20 AM","Operating Systems and Networki","Victor T. Norman","","","","","","2024-11-12T16:56:28-05:00"
+"Computer Science",FA,"CS",262,A,200,4, 4,"SB 354
+SC 120","F
+MW","1:30PM - 3:50PM
+1:30PM - 2:35PM",,,Full,"SB
+SC","354
+120","1:30 PM
+1:30 PM","140
+65","3:50 PM
+2:35 PM","Software Engineering","Keith VanderLinden","","","","","","2021-07-13T14:16:19-04:00"
+"Computer Science",FA,"CS",262,B,200,4, 4,"SC 120
+SB 337","MW
+F","2:45PM - 3:50PM
+1:30PM - 3:50PM",,,Full,"SC
+SB","120
+337","2:45 PM
+1:30 PM","65
+140","3:50 PM
+3:50 PM","Software Engineering","Victor T. Norman","","","","","","2021-07-13T14:16:34-04:00"
+"Computer Science",FA,"CS",295,A,200,0, 0.5,"SB 010","T","3:05PM - 3:55PM",,,Full,"SB","010","3:05 PM","50","3:55 PM","Computing Seminar","Derek C Schuurman","","","","","","2024-11-09T13:40:47-05:00"
+"Computer Science",SP,"CS",295,A,200,0, 0.5,"SB 010","T","3:05PM - 3:55PM",,,Full,"SB","010","3:05 PM","50","3:55 PM","Computing Seminar","Derek C Schuurman","","","","","","2024-11-09T13:41:13-05:00"
+"Computer Science",FA,"CS",300,A,300,2, 2,"SB 382","MWF","11:00AM - 12:05PM",,,First,"SB","382","11:00 AM","65","12:05 PM","Applied Machine Learning","Kenneth C Arnold","","","","","","2025-02-04T14:44:51-05:00"
+"Computer Science",SP,"CS",300,A,300,4, 4,"SB 382","MWF","12:15PM - 1:20PM",,,Full,"SB","382","12:15 PM","65","1:20 PM","Network Security","Rocky Chang","","","","","","2025-02-04T14:47:22-05:00"
+"Computer Science",FA,"CS",300,B,300,2, 2,"SB 382","MWF","11:00AM - 12:05PM",,,Second,"SB","382","11:00 AM","65","12:05 PM","Design Patterns","Victor T. Norman","","","","","","2025-02-04T14:44:59-05:00"
+"Computer Science",FA,"CS",336,A,300,4, 4,"HH 336","MWF","9:15AM - 10:20AM",,,Full,"HH","336","9:15 AM","65","10:20 AM","Web Development","Victor T. Norman","","","","","","2024-10-26T12:37:43-04:00"
+"Computer Science",SP,"CS",338,A,300,2, 2,"SB 382","MWF","8:00AM - 9:05AM",,,First,"SB","382","8:00 AM","65","9:05 AM","System Administration: Infrastructure","Christopher Wieringa","","","","","","2024-10-03T11:38:00-04:00"
+"Computer Science",SP,"CS",339,A,300,2, 2,"SB 382","MWF","8:00AM - 9:05AM",,,Second,"SB","382","8:00 AM","65","9:05 AM","System Administration: Cloud Services","Christopher Wieringa","","","","","","2024-10-03T11:38:11-04:00"
+"Computer Science",SP,"CS",354,A,300,2, 2,"SB 382","MWF","9:15AM - 10:20AM",,,Second,"SB","382","9:15 AM","65","10:20 AM","Database Management Systems","Eric Araujo","","","","","","2024-10-03T11:37:50-04:00"
+"Computer Science",FA,"CS",364,A,300,4, 4,"SB 372","MTH","7:00PM - 8:40PM",,,Full,"SB","372","7:00 PM","100","8:40 PM","Computer Security","Brian D Paige
+Adam Vedra","","","","","","2023-11-22T11:29:39-05:00"
+"Computer Science",SP,"CS",372,A,300,2, 2,"SB 382","MWF","9:15AM - 10:20AM",,,First,"SB","382","9:15 AM","65","10:20 AM","Computer Graphics","Harry Plantinga","","","","","","2024-10-04T09:19:10-04:00"
+"Computer Science",FA,"CS",374,A,300,2, 2,"SB 382","MWF","2:45PM - 3:50PM",,,Second,"SB","382","2:45 PM","65","3:50 PM","High Performance Computing","Joel Adams","","","","","","2024-10-03T11:48:09-04:00"
+"Computer Science",SP,"CS",375,A,300,2, 2,"SB 382","MWF","11:00AM - 12:05PM",,,First,"SB","382","11:00 AM","65","12:05 PM","Artificial Intelligence","Kenneth C Arnold","","","","","","2025-02-04T14:47:10-05:00"
+"Computer Science",SP,"CS",376,A,300,2, 2,"SB 382","MWF","11:00AM - 12:05PM",,,Second,"SB","382","11:00 AM","65","12:05 PM","Machine Learning","Kenneth C Arnold","","","","","","2024-09-10T10:39:10-04:00"
+"Computer Science",FA,"CS",383,A,300,1, 0,"SB 382","TH","7:00PM - 7:50PM",,,Full,"SB","382","7:00 PM","50","7:50 PM","Senior Internship in Computing","Derek C Schuurman","","","","","","2024-09-16T18:41:49-04:00"
+"Computer Science",SP,"CS",383,A,300,1, 0,"SB 382","TH","7:00PM - 7:50PM",,,Full,"SB","382","7:00 PM","50","7:50 PM","External Practicum","Derek C Schuurman","","","","","","2024-09-16T18:42:07-04:00"
+"Computer Science",SP,"CS",384,A,300,4, 4,"HH 336","TTH","10:20AM - 12:00PM",,,Full,"HH","336","10:20 AM","100","12:00 PM","Perspectives on Computing","Derek C Schuurman","","","","","","2024-01-22T14:03:06-05:00"
+"Computer Science",SP,"CS",384,B,300,4, 4,"HH 336","TTH","12:15PM - 1:55PM",,,Full,"HH","336","12:15 PM","100","1:55 PM","Perspectives on Computing","Derek C Schuurman","","","","","","2024-01-22T14:03:12-05:00"
+"Computer Science",FA,"CS",396,A,300,2, 0.25,"SB 382","T","7:00PM - 7:50PM",,,Full,"SB","382","7:00 PM","50","7:50 PM","Senior Project in Computing I","Kenneth C Arnold","","","","","","2024-10-26T11:41:42-04:00"
+"Computer Science",SP,"CS",398,A,300,2, 0.25,"SB 382","T","7:00PM - 7:50PM",,,Full,"SB","382","7:00 PM","50","7:50 PM","Senior Project in Computing II","Kenneth C Arnold","","","","","","2024-10-26T11:42:11-04:00"
+"Computer Science",FA,"DATA",102,A,100,2, 2,"SB 354","TTH","8:00AM - 9:40AM",,,First,"SB","354","8:00 AM","100","9:40 AM","Foundations of Data Science and Analytics","Jim Momeyer","","","","","","2025-04-09T16:56:36-04:00"
+"Computer Science",SP,"DATA",102,A,100,2, 2,"SB 354","MWF","9:15AM - 10:20AM",,,First,"SB","354","9:15 AM","65","10:20 AM","Foundations of Data Science and Analytics","Fernando Pasquini Santos","","","","","Monica is busy with ENGR labs all day Thursday.
+Set as on-hold? we may not have the enrollment.","2025-04-09T16:58:53-04:00"
+"Computer Science",FA,"DATA",102,B,100,2, 2,"SB 354","TTH","12:15PM - 1:55PM",,,First,"SB","354","12:15 PM","100","1:55 PM","Foundations of Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:27:01-05:00"
+"Computer Science",SP,"DATA",102,B,100,2, 2,"SB 354","TTH","12:15PM - 1:55PM",,,First,"SB","354","12:15 PM","100","1:55 PM","Foundations of Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:28:27-05:00"
+"Computer Science",FA,"DATA",102,C,100,2, 2,"SB 354","TTH","2:10PM - 3:50PM",,,First,"SB","354","2:10 PM","100","3:50 PM","Foundations of Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:26:32-05:00"
+"Computer Science",SP,"DATA",102,C,100,2, 2,"SB 354","TTH","2:10PM - 3:50PM",,,First,"SB","354","2:10 PM","100","3:50 PM","Foundations of Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:28:32-05:00"
+"Computer Science",FA,"DATA",102,D,100,2, 2,"SB 354","TTH","7:00PM - 8:40PM",,,First,"SB","354","7:00 PM","100","8:40 PM","Foundations of Data Science and Analytics","Jim Momeyer","","","","","","2023-11-22T11:29:48-05:00"
+"Computer Science",SP,"DATA",102,D,100,2, 2,"SB 354","TTH","7:00PM - 8:40PM",,,First,"SB","354","7:00 PM","100","8:40 PM","Foundations of Data Science and Analytics","Jim Momeyer","","","","","","2023-11-22T11:30:43-05:00"
+"Computer Science",FA,"DATA",102,E,100,2, 2,"SB 354","TTH","8:00AM - 9:40AM",,,Second,"SB","354","8:00 AM","100","9:40 AM","Exploratory Data Science and Analytics","Jim Momeyer","","","","","","2025-04-09T16:57:00-04:00"
+"Computer Science",SP,"DATA",102,E,100,2, 2,"SB 354","MWF","9:15AM - 10:20AM",,,Second,"SB","354","9:15 AM","65","10:20 AM","Exploratory Data Science and Analytics","Fernando Pasquini Santos","","","","","Monica is busy with ENGR labs all day Thursday.
+Set as on-hold? we may not have the enrollment.","2025-04-09T16:59:03-04:00"
+"Computer Science",FA,"DATA",102,F,100,2, 2,"SB 354","TTH","12:15PM - 1:55PM",,,Second,"SB","354","12:15 PM","100","1:55 PM","Exploratory Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:26:47-05:00"
+"Computer Science",SP,"DATA",102,F,100,2, 2,"SB 354","TTH","12:15PM - 1:55PM",,,Second,"SB","354","12:15 PM","100","1:55 PM","Exploratory Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:28:40-05:00"
+"Computer Science",FA,"DATA",102,G,100,2, 2,"SB 354","TTH","2:10PM - 3:50PM",,,Second,"SB","354","2:10 PM","100","3:50 PM","Exploratory Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:26:39-05:00"
+"Computer Science",SP,"DATA",102,G,100,2, 2,"SB 354","TTH","2:10PM - 3:50PM",,,Second,"SB","354","2:10 PM","100","3:50 PM","Exploratory Data Science and Analytics","Cancelled-DATA","","","","","","2024-11-12T09:28:46-05:00"
+"Computer Science",FA,"DATA",102,H,100,2, 2,"SB 354","TTH","7:00PM - 8:40PM",,,Second,"SB","354","7:00 PM","100","8:40 PM","Exploratory Data Science and Analytics","Jim Momeyer","","","","","","2023-11-22T11:29:59-05:00"
+"Computer Science",SP,"DATA",102,H,100,2, 2,"SB 354","TTH","7:00PM - 8:40PM",,,Second,"SB","354","7:00 PM","100","8:40 PM","Exploratory Data Science and Analytics","Jim Momeyer","","","","","","2023-11-22T11:30:50-05:00"
+"Computer Science",FA,"DATA",202,A,200,4, 4,"SB 382","MWF","8:00AM - 9:05AM",,,Full,"SB","382","8:00 AM","65","9:05 AM","Predictive Analytics","Fernando Pasquini Santos","","","","","","2024-01-22T14:20:46-05:00"
+"Computer Science",FA,"DATA",202,B,200,4, 4,"SB 382","MWF","9:15AM - 10:20AM",,,Full,"SB","382","9:15 AM","65","10:20 AM","Predictive Analytics","Fernando Pasquini Santos","","","","","","2024-01-22T14:20:58-05:00"
+"Computer Science",FA,"DATA",396,A,300,2, 0.25,"SB 382","T","7:00PM - 7:50PM",,,Full,"SB","382","7:00 PM","50","7:50 PM","Senior Project in Data Science","Kenneth C Arnold","","","","","","2024-10-26T11:41:53-04:00"
+"Computer Science",SP,"DATA",398,A,300,2, 0.25,"SB 382","T","7:00PM - 7:50PM",,,Full,"SB","382","7:00 PM","50","7:50 PM","Senior Project in Data Science II","Kenneth C Arnold","","","","","","2024-10-26T11:42:25-04:00"
+"Computer Science",FA,"DATA",501,A,500,2, 2,"","","",,,First,"","","","","","Data Wrangling","Cancelled-MDS","","","","","","2022-11-24T12:35:39-05:00"
+"Computer Science",FA,"DATA",502,A,500,2, 2,"","","",,,Second,"","","","","","Introduction to Machine Learning","Cancelled-MDS","","","","","","2022-11-24T12:36:48-05:00"
+"Computer Science",SU,"DATA",504,A,500,2, 2,"","","",,,First,"","","","","","Visualization for Data Science","Cancelled-MDS","","","","","","2024-01-18T15:46:07-05:00"
+"Computer Science",SP,"DATA",510,A,500,2, 2,"","","",,,First,"","","","","","Ethics for Data Science","Cancelled-MDS","","","","","","2022-11-24T12:32:13-05:00"
+"Computer Science",SU,"DATA",539,A,500,2, 2,"","","",,,Second,"","","","","","Administering Cloud Services","Cancelled-MDS","","","","","","2023-01-25T14:16:32-05:00"
+"Computer Science",SP,"DATA",562,A,500,4, 4,"","","",,,Full,"","","","","","Systems Engineering for Data Science","Cancelled-MDS","","","","","","2022-11-24T12:33:33-05:00"
+"Computer Science",SU,"DATA",654,A,600,2, 2,"","","",,,Second,"","","","","","Database Management Systems","Cancelled-MDS","","","","","","2022-11-24T12:38:36-05:00"
+"Computer Science",SP,"DATA",675,A,600,2, 2,"","","",,,Second,"","","","","","Introduction to Deep Learning","Cancelled-MDS","","","","","","2022-11-24T12:39:51-05:00"
+"Computer Science",SU,"DATA",676,A,600,2, 2,"","","",,,First,"","","","","","Deep Learning for Text and Generative Models","Cancelled-MDS","","","","","","2022-11-24T12:40:54-05:00"
+"Computer Science",SU,"DATA",696,A,600,2, 2,"","","",,,Full,"","","","","","Project in Data Science","Cancelled-MDS","","","","","","2022-11-24T12:52:05-05:00"
+"Computer Science",SU,"DATA",698,A,600,2, 2,"","","",,,Second,"","","","","","Project in Data Science","Cancelled-MDS","","","","","","2024-01-18T15:43:05-05:00"
+"Computer Science",FA,"HNRS",251,A,200,2, 2,"HL 406C","TTH","2:10PM - 3:15PM",,,Full,"HL","406C","2:10 PM","65","3:15 PM","Agent Modeling","Eric Araujo","","","","","","2025-02-05T12:57:19-05:00"
+"Shadow",FA,"CS",300-S,A-S,300,0, 0,"SB 354","MWF","11:00AM - 12:05PM",,,First,"SB","354","11:00 AM","65","12:05 PM","Applied Machine Learning","Shadow-Gold","","","","","","2024-01-22T15:07:10-05:00"
+"Shadow",SP,"CS",300-S,A-S,300,0, 0,"SB 354","MWF","12:15PM - 1:20PM",,,Full,"SB","354","12:15 PM","65","1:20 PM","Network Security","Shadow-Gold","","","","","","2025-01-28T17:45:40-05:00"
+"Shadow",FA,"CS",300-S,B-S,300,0, 0,"SB 354","MWF","11:00AM - 12:05PM",,,Second,"SB","354","11:00 AM","65","12:05 PM","Design Patterns","Shadow-Gold","","","","","","2024-01-22T15:07:10-05:00"
+"Shadow",SP,"CS",338-S,A-S,300,0, 0,"SB 354","MWF","8:00AM - 9:05AM",,,First,"SB","354","8:00 AM","65","9:05 AM","System Administration: Infrastructure","Shadow-Gold","","","","","","2024-10-03T11:41:27-04:00"
+"Shadow",SP,"CS",339-S,A-S,300,0, 0,"SB 354","MWF","8:00AM - 9:05AM",,,Second,"SB","354","8:00 AM","65","9:05 AM","System Administration: Cloud Services","Shadow-Gold","","","","","","2024-10-03T11:41:34-04:00"
+"Shadow",FA,"CS",374-S,A-S,300,2, 2,"SB 354","MW","2:45PM - 3:50PM",,,Second,"SB","354","2:45 PM","65","3:50 PM","High-Performance Computing","Shadow-Gold","","","","","","2024-10-26T12:28:48-04:00"
+"Shadow",SP,"CS",375-S,A-S,300,0, 0,"SB 354","MWF","11:00AM - 12:05PM",,,First,"SB","354","11:00 AM","65","12:05 PM","Artificial Intelligence","Shadow-Gold","","","","","","2025-01-28T17:37:32-05:00"
+"Shadow",SP,"CS",376-S,B-S,300,0, 0,"SB 354","MWF","11:00AM - 12:05PM",,,Second,"SB","354","11:00 AM","65","12:05 PM","Machine Learning","Shadow-Gold","","","","","","2024-04-29T13:03:38-04:00"
+"Shadow",FA,"DATA",202-S,A-S,200,0, 0,"SB 354","MWF","8:00AM - 9:05AM",,,Full,"SB","354","8:00 AM","65","9:05 AM","Predictive Analytics","Shadow-Maroon","","","","","","2024-11-27T13:25:35-05:00"
+"Shadow",FA,"DATA",202-S,B-S,200,0, 0,"SB 354","MWF","9:15AM - 10:20AM",,,Full,"SB","354","9:15 AM","65","10:20 AM","Predictive Analytics","Shadow-Maroon","","","","","","2024-11-27T13:25:44-05:00"

--- a/client-course-schedulizer/src/utilities/hooks/addSectionHooks.ts
+++ b/client-course-schedulizer/src/utilities/hooks/addSectionHooks.ts
@@ -90,12 +90,20 @@ export const useAddSectionToSchedule = () => {
       meeting.isNonstandardTime = !isStandardTime(meeting)
     });
 
-    // Create a copy of the schedules array
+    // Create a copy of the schedules array. If there are no schedules yet,
+    // initialize with the current display `schedule` so there is a target to update.
     const updatedSchedules = [...schedules];
+    if (updatedSchedules.length === 0) {
+      updatedSchedules.push(JSON.parse(JSON.stringify(schedule || { courses: [], numDistinctSchedules: 0 })));
+    }
 
     // IMPORTANT: Only target active schedules, regardless of which schedules contain the section
     // This ensures we only modify visible schedules
     let targetScheduleIds: number[] = [...activeScheduleIds];
+    // If no active schedule ids exist (fresh app), default to the first schedule
+    if (!targetScheduleIds || targetScheduleIds.length === 0) {
+      targetScheduleIds = [0];
+    }
 
     // Only update the target schedules
     targetScheduleIds.forEach(scheduleId => {
@@ -152,12 +160,12 @@ export const useAddSectionToSchedule = () => {
     });
 
     // Generate the combined display schedule from the updated schedules
-    const displaySchedule = combineActiveSchedules(updatedSchedules, activeScheduleIds);
+    const displaySchedule = combineActiveSchedules(updatedSchedules, targetScheduleIds);
 
     // Dispatch with all schedule state preserved
     appDispatch({
       payload: {
-        activeScheduleIds,
+        activeScheduleIds: targetScheduleIds,
         schedule: displaySchedule,
         schedules: updatedSchedules,
       },


### PR DESCRIPTION
When [addToSchedule] is called, it first creates a copy of the existing schedules array. The main change is that, if there are no schedules yet, the function now initializes the array with a new schedule based on either the current display schedule or a fresh empty schedule structure. 

By providing this default initialization, the system now has a valid target schedule to work with, even when no schedules have been imported. 